### PR TITLE
protect queries against sql injections; use more 'wpdb' functions 

### DIFF
--- a/class/UamUserGroup.php
+++ b/class/UamUserGroup.php
@@ -113,9 +113,9 @@ class UamUserGroup
 
         $oDatabase = $this->getAccessHandler()->getUserAccessManager()->getDatabase();
         
-        $oDatabase->query(
-            "DELETE FROM " . DB_ACCESSGROUP . "
-            WHERE ID = {$this->_iId} LIMIT 1"
+        $oDatabase->delete(
+            DB_ACCESSGROUP,
+            array( 'ID' => $this->_iId)
         );
         
         foreach ($this->getAllObjectTypes() as $sObjectType) {
@@ -135,39 +135,44 @@ class UamUserGroup
         $oDatabase = $this->getAccessHandler()->getUserAccessManager()->getDatabase();
         
         if ($this->_iId == null) {
-            $sInsertQuery = "
-                INSERT INTO " . DB_ACCESSGROUP . " (
-                    ID,
-                    groupname,
-                    groupdesc,
-                    read_access,
-                    write_access,
-                    ip_range
+            $oDatabase->insert(
+                DB_ACCESSGROUP,
+                array(
+                    'groupname'    => $this->_sGroupName,
+                    'groupdesc'    => $this->_sGroupDesc,
+                    'read_access'  => $this->_sReadAccess,
+                    'write_access' => $this->_sWriteAccess,
+                    'ip_range'     => $this->_sIpRange
+                ),
+                array(
+                    '%s',
+                    '%s',
+                    '%s',
+                    '%s',
+                    '%s',
                 )
-                VALUES (
-                    NULL,
-                    '{$this->_sGroupName}',
-                    '{$this->_sGroupDesc}',
-                    '{$this->_sReadAccess}',
-                    '{$this->_sWriteAccess}',
-                    '{$this->_sIpRange}'
-                )";
-
-            $oDatabase->query($sInsertQuery);
+            );
             
             $this->_iId = $oDatabase->insert_id;
         } else {
-            $sAccessGroupTable = DB_ACCESSGROUP;
-            $sUpdateQuery = "
-                UPDATE {$sAccessGroupTable} 
-                SET groupname = '{$this->_sGroupName}',
-                    groupdesc = '{$this->_sGroupDesc}',
-                    read_access = '{$this->_sReadAccess}',
-                    write_access = '{$this->_sWriteAccess}',
-                    ip_range = '{$this->_sIpRange}'
-                WHERE ID = {$this->_iId}";
-
-            $oDatabase->query($sUpdateQuery);
+            $oDatabase->update(
+                DB_ACCESSGROUP,
+                array(
+                    'groupname'    => $this->_sGroupName,
+                    'groupdesc'    => $this->_sGroupDesc,
+                    'read_access'  => $this->_sReadAccess,
+                    'write_access' => $this->_sWriteAccess,
+                    'ip_range'     => $this->_sIpRange
+                ),
+                array( 'ID' => $this->_iId),
+                array(
+                    '%s',
+                    '%s',
+                    '%s',
+                    '%s',
+                    '%s',
+                )
+            );
 
             if ($blRemoveOldAssignments === true) {
                 foreach ($this->getAllObjectTypes() as $sObjectType) {

--- a/class/UamUserGroup.php
+++ b/class/UamUserGroup.php
@@ -143,13 +143,6 @@ class UamUserGroup
                     'read_access'  => $this->_sReadAccess,
                     'write_access' => $this->_sWriteAccess,
                     'ip_range'     => $this->_sIpRange
-                ),
-                array(
-                    '%s',
-                    '%s',
-                    '%s',
-                    '%s',
-                    '%s',
                 )
             );
             
@@ -164,14 +157,7 @@ class UamUserGroup
                     'write_access' => $this->_sWriteAccess,
                     'ip_range'     => $this->_sIpRange
                 ),
-                array( 'ID' => $this->_iId),
-                array(
-                    '%s',
-                    '%s',
-                    '%s',
-                    '%s',
-                    '%s',
-                )
+                array( 'ID' => $this->_iId)
             );
 
             if ($blRemoveOldAssignments === true) {

--- a/class/UserAccessManager.php
+++ b/class/UserAccessManager.php
@@ -498,13 +498,7 @@ class UserAccessManager
                     ),
                     array(
                         'object_type' => 'category',
-                    ),
-                    array(
-                        '%s',
-                    ),
-                    array(
-                        '%s',
-                    ),
+                    )
                 );
             }
             

--- a/class/UserAccessManager.php
+++ b/class/UserAccessManager.php
@@ -453,18 +453,19 @@ class UserAccessManager
                     $aDbObjects = $oDatabase->get_results($sSql);
                     
                     foreach ($aDbObjects as $oDbObject) {
-                        $sSql = "INSERT INTO {$sDbAccessGroupToObject} (
-                                group_id, 
-                                object_id,
-                                object_type
-                            ) 
-                            VALUES(
-                                '{$oDbObject->groupId}',
-                                '{$oDbObject->id}',
-                                '{$sObjectType}'
-                            )";
-                        
-                        $oDatabase->query($sSql);
+                        $oDatabase->insert(
+                            $sDbAccessGroupToObject,
+                            array(
+                                'group_id' => $oDbObject->groupId,
+                                'object_id' => $oDbObject->id,
+                                'object_type' => $sObjectType,
+                            ),
+                            array(
+                                '%d',
+                                '%d',
+                                '%s',
+                            )
+                        );
                     } 
                 }
                 
@@ -490,13 +491,21 @@ class UserAccessManager
             if (version_compare($sCurrentDbVersion, "1.3", '<=')) {
                 $sDbAccessGroupToObject = $oDatabase->prefix.'uam_accessgroup_to_object';
                 $sTermType = UserAccessManager::TERM_OBJECT_TYPE;
-
-                $sSql = "
-                    UPDATE `{$sDbAccessGroupToObject}` AS ag2o
-                    SET ag2o.`object_type` = '{$sTermType}'
-                    WHERE `object_type` = 'category'";
-
-                $oDatabase->query($sSql);
+                $oDatabase->update(
+                    $sDbAccessGroupToObject,
+                    array(
+                        'object_type' => $sTermType,
+                    ),
+                    array(
+                        'object_type' => 'category',
+                    ),
+                    array(
+                        '%s',
+                    ),
+                    array(
+                        '%s',
+                    ),
+                );
             }
             
             update_option('uam_db_version', $this->_sUamDbVersion);
@@ -1123,10 +1132,16 @@ class UserAccessManager
     {
         $oDatabase = $this->getDatabase();
 
-        $oDatabase->query(
-            "DELETE FROM " . DB_ACCESSGROUP_TO_OBJECT . " 
-            WHERE object_id = {$iId}
-                AND object_type = '{$sObjectType}'"
+        $oDatabase->delete(
+            DB_ACCESSGROUP_TO_OBJECT,
+            array(
+                'object_id' => $iId ,
+                'object_type' => $sObjectType,
+            ),
+            array(
+                '%d',
+                '%s',
+            )
         );
     }
 
@@ -1232,10 +1247,16 @@ class UserAccessManager
         $oDatabase = $this->getDatabase();
         $oPost = $this->getPost($iPostId);
         
-        $oDatabase->query(
-            "DELETE FROM " . DB_ACCESSGROUP_TO_OBJECT . " 
-            WHERE object_id = '".$iPostId."'
-                AND object_type = '".$oPost->post_type."'"
+        $oDatabase->delete(
+            DB_ACCESSGROUP_TO_OBJECT,
+            array(
+                'object_id' => $iPostId,
+                'object_type' => $oPost->post_type,
+            ),
+            array(
+                '%d',
+                '%s',
+            )
         );
     }
     


### PR DESCRIPTION
@see https://codex.wordpress.org/Class_Reference/wpdb#Protect_Queries_Against_SQL_Injection_Attacks

replaced calls to '->query(' with 'insert,update,delete'
-in order to prevent sql-injection possibilities it is adviced to prepare SQL queries
-using insert, update and delete functions will call 'prepare' to escape the parameters properly
-it should also enhace readability and maintainability