### PR TITLE
Empty vs count

### DIFF
--- a/class/UamAccessHandler.php
+++ b/class/UamAccessHandler.php
@@ -768,7 +768,7 @@ class UamAccessHandler
             $aCapabilities = array();
         }
         
-        $aRoles = (is_array($aCapabilities) && count($aCapabilities) > 0) ? array_keys($aCapabilities) : array('norole');
+        $aRoles = (is_array($aCapabilities) && !empty($aCapabilities)) ? array_keys($aCapabilities) : array('norole');
         return $aRoles;
     }
     

--- a/class/UamUserGroup.php
+++ b/class/UamUserGroup.php
@@ -171,7 +171,7 @@ class UamUserGroup
         foreach ($this->getAllObjectTypes() as $sObjectType) {
             $aKeys = $this->_getAssignedObjects($sObjectType);
 
-            if (count($aKeys) > 0) {
+            if (!empty($aKeys)) {
                 $sSql = $this->_getSqlQuery($sObjectType, 'insert', $aKeys);
                 $oDatabase->query($sSql);
             }
@@ -783,7 +783,7 @@ class UamUserGroup
             $aCapabilities = array();
         }
         
-        $aRoles = (is_array($aCapabilities) && count($aCapabilities) > 0) ? array_keys($aCapabilities) : array('norole');
+        $aRoles = (is_array($aCapabilities) && !empty($aCapabilities)) ? array_keys($aCapabilities) : array('norole');
         $aObjects = $this->getObjectsFromType('role');
 
         foreach ($aRoles as $sRole) {

--- a/class/UserAccessManager.php
+++ b/class/UserAccessManager.php
@@ -1515,7 +1515,7 @@ class UserAccessManager
         $aExcludedPosts = $oUamAccessHandler->getExcludedPosts();
         $aAllExcludedPosts = $aExcludedPosts['all'];
 
-        if (count($aAllExcludedPosts) > 0) {
+        if (!empty($aAllExcludedPosts)) {
             $oWpQuery->query_vars['post__not_in'] = array_merge(
                 $oWpQuery->query_vars['post__not_in'],
                 $aAllExcludedPosts
@@ -1630,7 +1630,7 @@ class UserAccessManager
         $aExcludedPosts = $oUamAccessHandler->getExcludedPosts();
         $aAllExcludedPosts = $aExcludedPosts['all'];
 
-        if (count($aAllExcludedPosts) > 0) {
+        if (!empty($aAllExcludedPosts)) {
             $sExcludedPostsStr = implode(',', $aAllExcludedPosts);
             $sSql .= " AND $oDatabase->posts.ID NOT IN($sExcludedPostsStr) ";
         }
@@ -2116,7 +2116,7 @@ class UserAccessManager
         $aExcludedPosts = $oUamAccessHandler->getExcludedPosts();
         $aAllExcludedPosts = $aExcludedPosts['all'];
             
-        if (count($aAllExcludedPosts) > 0) {
+        if (!empty($aAllExcludedPosts)) {
             $sExcludedPosts = implode(',', $aAllExcludedPosts);
             $sSql.= " AND p.ID NOT IN({$sExcludedPosts}) ";
         }
@@ -2156,7 +2156,7 @@ class UserAccessManager
                 $oUamAccessHandler = $this->getAccessHandler();
 
                 if ($oUamAccessHandler->userIsAdmin($oCurrentUser->ID)
-                    && count($oUamAccessHandler->getUserGroupsForObject($sObjectType, $iObjectId)) > 0
+                    && !empty($oUamAccessHandler->getUserGroupsForObject($sObjectType, $iObjectId))
                 ) {
                     $sOutput .= $sHintText;
                 }
@@ -2179,7 +2179,7 @@ class UserAccessManager
         $oUamAccessHandler = $this->getAccessHandler();
         $aGroups = $oUamAccessHandler->getUserGroupsForObject(self::POST_OBJECT_TYPE, $iPostId);
         
-        if (count($aGroups) > 0) {
+        if (!empty($aGroups)) {
             $sLink .= ' | '.TXT_UAM_ASSIGNED_GROUPS.': ';
             
             foreach ($aGroups as $oGroup) {

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -118,7 +118,7 @@ class Groups_Command extends \WP_CLI\CommandWithDBObject
      */
     public function del($_, $assoc_args)
     {
-        if (count($_) < 1) {
+        if (empty($_)) {
             WP_CLI::error('Expected: wp uam groups del <id> ..');
         }
 

--- a/tpl/groupInfo.php
+++ b/tpl/groupInfo.php
@@ -56,7 +56,7 @@ foreach ($oUserAccessManager->getAccessHandler()->getAllObjectTypes() as $sCurOb
     if (isset($aUserGroups[$oUamUserGroup->getId()])) {
         $aRecursiveMembership = $aUserGroups[$oUamUserGroup->getId()]->getRecursiveMembershipForObjectType($sObjectType, $iObjectId, $sCurObjectType);
 
-        if (count($aRecursiveMembership) > 0) {
+        if (!empty($aRecursiveMembership)) {
             ?>
             <li  class="uam_group_info_head">
             <?php echo constant('TXT_UAM_GROUP_MEMBERSHIP_BY_'.strtoupper($sCurObjectType)); ?>:

--- a/tpl/postEditForm.php
+++ b/tpl/postEditForm.php
@@ -34,7 +34,7 @@ if (isset($iObjectId)) {
     $aUserGroupsForObject = array();
 }
 
-if (count($aUamUserGroups) > 0) {
+if (!empty($aUamUserGroups)) {
     include 'groupSelectionForm.php';
 } elseif ($oUserAccessManager->getAccessHandler()->checkUserAccess()) {
     ?>

--- a/tpl/termEditForm.php
+++ b/tpl/termEditForm.php
@@ -41,7 +41,7 @@ if (isset($_GET['tag_ID'])) {
             </th>
             <td>
 <?php
-if (count($aUamUserGroups) > 0) {
+if (!empty($aUamUserGroups)) {
     include 'groupSelectionForm.php';
 } elseif ($oUserAccessManager->getAccessHandler()->checkUserAccess()) {
     ?>


### PR DESCRIPTION
I think common opinion is, that 'empty' should be used over 'count  < 1', '!empty' vs 'count > 0' repectively
-additionally, it enhances readability, since the relational operator is written later in the line, while 'empty' starts the line
-without the operator the code is shorter