### PR TITLE
setAtAdminPanel was called too late using the amin_init filter

### DIFF
--- a/class/UserAccessManager.php
+++ b/class/UserAccessManager.php
@@ -41,7 +41,6 @@ class UserAccessManager
     CONST HANDLE_SCRIPT_ADMIN = 'UserAccessManagerFunctions';
 
     protected $_oConfig = null;
-    protected $_blAtAdminPanel = false;
     protected $_sUamVersion = '1.2.14';
     protected $_sUamDbVersion = '1.4';
     protected $_oAccessHandler = null;
@@ -904,18 +903,9 @@ class UserAccessManager
      */
     public function atAdminPanel()
     {
-        return $this->_blAtAdminPanel;
+        return is_admin();
     }
-    
-    /**
-     * Sets the atAdminPanel var to true.
-     */
-    public function setAtAdminPanel()
-    {
-        $this->_blAtAdminPanel = true;
-    }
-    
-    
+
     /*
      * Helper functions.
      */

--- a/user-access-manager.php
+++ b/user-access-manager.php
@@ -100,7 +100,6 @@ if (!function_exists("userAccessManagerAP")) {
             return;
         }
 
-        $oUserAccessManager->setAtAdminPanel();
         $oConfig = $oUserAccessManager->getConfig();
 
         if ($oUserAccessManager->isDatabaseUpdateNecessary()) {


### PR DESCRIPTION
-wordpress might have changed something in the order filter and actions are called? Or someting somewhere in the code has changed in the order things are executed
-the admin_init action is called too late, so that setAtAdminPanel is not set to true and the call to $oUserAccessManager->noRightsToEditContent() does not work properly since it relies on that
-replaced that logic by implementing 'atAdminPanel' using worpdress' is_admin() function https://codex.wordpress.org/Function_Reference/is_admin
