### PR TITLE
Post tree map improvement

### DIFF
--- a/class/UamAccessHandler.php
+++ b/class/UamAccessHandler.php
@@ -444,8 +444,8 @@ class UamAccessHandler
                         break;
                     }
                     // if the group grants write access to all on admin panel, or read access to all remove the group from the object
-                    elseif (($this->getUserAccessManager()->atAdminPanel() && $oUserGroup->getWriteAccess() == 'all')
-                        || (!$this->getUserAccessManager()->atAdminPanel() && $oUserGroup->getReadAccess() == 'all')
+                    elseif ($this->getUserAccessManager()->atAdminPanel() && $oUserGroup->getWriteAccess() == 'all'
+                        || !$this->getUserAccessManager()->atAdminPanel() && $oUserGroup->getReadAccess() == 'all'
                     ) {
                         unset($aMembership[$sKey]);
                     }


### PR DESCRIPTION
This is my attempt to fix the problem in hierarchical posts.
The previous siblings map (which is still used for terms) makes things a little harder to wrap ones head around. The basic idea of this proposed implementation is, that for each post, all ancestors (parents, parents of parents ...) are stored .
It would be nicer and more efficient, if this would be done on the database. The keyword is https://en.wikipedia.org/wiki/Transitive_closure
But wordpress does not have an api for that ancestor map of a post (or term). And each database provider has a slightly different way to implement that. So this might just be an unreachable goal.

Now if we want to test, if a user has access to that post, we need to check if there is no restriction on the parents, or if the user has explicit rights for any of the parents - either will grant access (or inverse will add them to excluded posts).