### PR TITLE
Fix for incorrect "authors have access to own" pages/post check

### DIFF
--- a/class/UamAccessHandler.php
+++ b/class/UamAccessHandler.php
@@ -418,7 +418,7 @@ class UamAccessHandler
 
             if ($this->isPostableType($sObjectType)) {
                 $oPost = $this->getUserAccessManager()->getPost($iObjectId);
-                $sAuthorId = $oPost->post_author;
+                $sAuthorId = (int) $oPost->post_author;
             } else {
                 $sAuthorId = -1;
             }


### PR DESCRIPTION
Currently authors can't access their own objects, if their only permission is granted by an activated "authors always have access to their own posts/pages" option. This is caused by "identically" comparing the (int) current user with (string) post author id. Typecasting the author ID to an int fixes this.