### PR TITLE
Add option to toggle visibility of assigned groups text next to the edit link

### DIFF
--- a/includes/language.php
+++ b/includes/language.php
@@ -93,6 +93,8 @@ define('TXT_UAM_OTHER_SETTING', __('Other settings', 'user-access-manager'));
 define('TXT_UAM_OTHER_SETTING_DESC', __('Here you will find all other settings', 'user-access-manager'));
 define('TXT_UAM_PROTECT_FEED', __('Protect Feed', 'user-access-manager'));
 define('TXT_UAM_PROTECT_FEED_DESC', __('Selecting "Yes" will also protect your feed entries.', 'user-access-manager'));
+define('TXT_UAM_SHOW_ASSIGNED_GROUPS', __('Show assigned groups', 'user-access-manager'));
+define('TXT_UAM_SHOW_ASSIGNED_GROUPS_DESC', __('Show assigned groups next to the edit link', 'user-access-manager'));
 define('TXT_UAM_REDIRECT', __('Redirect user', 'user-access-manager'));
 define('TXT_UAM_REDIRECT_DESC', __('Setup what happen if a user visit a post/page with no access.', 'user-access-manager'));
 define('TXT_UAM_REDIRECT_TO_BLOG', __('To blog start page', 'user-access-manager'));

--- a/src/UserAccessManager/Config/Config.php
+++ b/src/UserAccessManager/Config/Config.php
@@ -236,6 +236,9 @@ class Config
             $id = 'protect_feed';
             $configParameters[$id] = $this->configParameterFactory->createBooleanConfigParameter($id, true);
 
+            $id = 'show_assigned_groups';
+            $configParameters[$id] = $this->configParameterFactory->createBooleanConfigParameter($id, true);
+
             $id = 'full_access_role';
             $configParameters[$id] = $this->configParameterFactory->createSelectionConfigParameter(
                 $id,
@@ -601,6 +604,14 @@ class Config
     public function protectFeed()
     {
         return $this->getParameterValue('protect_feed');
+    }
+
+    /**
+     * @return bool
+     */
+    public function showAssignedGroups()
+    {
+        return $this->getParameterValue('show_assigned_groups');
     }
 
     /**

--- a/src/UserAccessManager/Controller/AdminSettingsController.php
+++ b/src/UserAccessManager/Controller/AdminSettingsController.php
@@ -168,6 +168,7 @@ class AdminSettingsController extends Controller
         $groupedConfigParameters['other'] = [
             $configParameters['lock_recursive'],
             $configParameters['protect_feed'],
+            $configParameters['show_assigned_groups'],
             $configParameters['redirect'],
             $configParameters['blog_admin_hint'],
             $configParameters['blog_admin_hint_text'],

--- a/src/UserAccessManager/UserAccessManager.php
+++ b/src/UserAccessManager/UserAccessManager.php
@@ -527,6 +527,10 @@ class UserAccessManager
             $this->wordpress->addFilter('wp_headers', [$frontendController, 'redirect'], 10, 2);
         }
 
+        if ($this->config->showAssignedGroups()) {
+            $this->wordpress->addFilter('edit_post_link', [$frontendController, 'showGroupMembership'], 10, 2);
+        }
+
         $this->wordpress->addFilter('wp_get_attachment_thumb_url', [$frontendController, 'getFileUrl'], 10, 2);
         $this->wordpress->addFilter('wp_get_attachment_url', [$frontendController, 'getFileUrl'], 10, 2);
         $this->wordpress->addFilter('posts_pre_query', [$frontendController, 'postsPreQuery'], 10, 2);
@@ -545,11 +549,6 @@ class UserAccessManager
         $this->wordpress->addFilter('get_next_post_where', [$frontendController, 'showNextPreviousPost']);
         $this->wordpress->addFilter('get_previous_post_where', [$frontendController, 'showNextPreviousPost']);
         $this->wordpress->addFilter('post_link', [$frontendController, 'cachePostLinks'], 10, 2);
-
-        if ($this->config->showAssignedGroups()) {
-            $this->wordpress->addFilter('edit_post_link', [$frontendController, 'showGroupMembership'], 10, 2);
-        }
-
         $this->wordpress->addFilter('parse_query', [$frontendController, 'parseQuery']);
         $this->wordpress->addFilter('getarchives_where', [$frontendController, 'showPostSql']);
         $this->wordpress->addFilter('wp_count_posts', [$frontendController, 'showPostCount'], 10, 3);

--- a/src/UserAccessManager/UserAccessManager.php
+++ b/src/UserAccessManager/UserAccessManager.php
@@ -115,7 +115,7 @@ class UserAccessManager
      * @var FileObjectFactory
      */
     private $fileObjectFactory;
-    
+
     /**
      * UserAccessManager constructor.
      *
@@ -545,7 +545,11 @@ class UserAccessManager
         $this->wordpress->addFilter('get_next_post_where', [$frontendController, 'showNextPreviousPost']);
         $this->wordpress->addFilter('get_previous_post_where', [$frontendController, 'showNextPreviousPost']);
         $this->wordpress->addFilter('post_link', [$frontendController, 'cachePostLinks'], 10, 2);
-        $this->wordpress->addFilter('edit_post_link', [$frontendController, 'showGroupMembership'], 10, 2);
+
+        if ($this->config->showAssignedGroups()) {
+            $this->wordpress->addFilter('edit_post_link', [$frontendController, 'showGroupMembership'], 10, 2);
+        }
+
         $this->wordpress->addFilter('parse_query', [$frontendController, 'parseQuery']);
         $this->wordpress->addFilter('getarchives_where', [$frontendController, 'showPostSql']);
         $this->wordpress->addFilter('wp_count_posts', [$frontendController, 'showPostCount'], 10, 3);

--- a/tests/UserAccessManager/Config/ConfigTest.php
+++ b/tests/UserAccessManager/Config/ConfigTest.php
@@ -67,6 +67,7 @@ class ConfigTest extends UserAccessManagerTestCase
             'blog_admin_hint_text' => 'string|blog_admin_hint_text|[L]',
             'hide_empty_category' => 'bool|hide_empty_category|true',
             'protect_feed' => 'bool|protect_feed|true',
+            'show_assigned_groups' => 'bool|show_assigned_groups|true',
             'full_access_role' => 'selection|full_access_role|administrator|'
                 .'administrator|editor|author|contributor|subscriber',
         ];
@@ -671,6 +672,7 @@ class ConfigTest extends UserAccessManagerTestCase
             'blogAdminHint' => 'blog_admin_hint',
             'getBlogAdminHintText' => 'blog_admin_hint_text',
             'protectFeed' => 'protect_feed',
+            'showAssignedGroups' => 'show_assigned_groups',
             'showPostContentBeforeMore' => 'show_post_content_before_more',
             'getFullAccessRole' => 'full_access_role'
         ];

--- a/tests/UserAccessManager/Config/ConfigTest.php
+++ b/tests/UserAccessManager/Config/ConfigTest.php
@@ -214,7 +214,7 @@ class ConfigTest extends UserAccessManagerTestCase
         $objectHandler = $this->getDefaultObjectHandler(2);
 
         $configParameterFactory = $this->getConfigParameterFactory();
-        $configParameterFactory->expects($this->exactly(16))
+        $configParameterFactory->expects($this->exactly(17))
             ->method('createBooleanConfigParameter')
             ->will($this->returnCallback(
                 function ($id, $value) {

--- a/tests/UserAccessManager/Controller/AdminSettingsControllerTest.php
+++ b/tests/UserAccessManager/Controller/AdminSettingsControllerTest.php
@@ -149,7 +149,7 @@ class AdminSettingsControllerTest extends UserAccessManagerTestCase
                 'category' => $this->createTypeObject('category'),
                 ObjectHandler::POST_FORMAT_TYPE => $this->createTypeObject('postFormat'),
             ]));
-        
+
         $configValues = [
             'hide_post' => 'hide_post',
             'hide_post_title' => 'hide_post_title',
@@ -182,6 +182,7 @@ class AdminSettingsControllerTest extends UserAccessManagerTestCase
             'blog_admin_hint_text' => 'blog_admin_hint_text',
             'hide_empty_category' => 'hide_empty_category',
             'protect_feed' => 'protect_feed',
+            'show_assigned_groups' => 'show_assigned_groups',
             'full_access_role' => 'full_access_role'
         ];
 
@@ -208,7 +209,7 @@ class AdminSettingsControllerTest extends UserAccessManagerTestCase
                 5 => 'post_comment_content',
                 6 => 'post_comments_locked',
                 7 => 'show_post_content_before_more'
-                
+
             ],
             'page' => [
                 0 => 'hide_page',
@@ -237,12 +238,13 @@ class AdminSettingsControllerTest extends UserAccessManagerTestCase
             'other' => [
                 0 => 'lock_recursive',
                 1 => 'protect_feed',
-                2 => 'redirect',
-                3 => 'blog_admin_hint',
-                4 => 'blog_admin_hint_text'
+                2 => 'show_assigned_groups',
+                3 => 'redirect',
+                4 => 'blog_admin_hint',
+                5 => 'blog_admin_hint_text'
             ]
         ];
-        
+
         self::assertEquals($expected, $adminSettingController->getGroupedConfigParameters());
         self::assertEquals($expected, $adminSettingController->getGroupedConfigParameters());
     }


### PR DESCRIPTION
I expected to find this option in the settings.

I've tried to follow the coding standards and added the new option to the tests in the `AdminSettingsControllerTest`. As I prevent the `addFilter`method being called in `UserAccessManager` I wasn't sure where you would test that, looking at the `wp_headers` `addFilter` call, which dependes on `getRedirect`,I assume it would be in the `UserAccessManagerTest`, but I'm not sure what the best way is to implement that test.

As of now that the `UserAccessManagerTest` test fails, but the `AdminSettingsControllerTest`is updated. I'm unfamiliar with your codebase but I hope this addition is useful.