### PR TITLE
Add a function to obtain the list of user groups

### DIFF
--- a/src/Access/AccessHandler.php
+++ b/src/Access/AccessHandler.php
@@ -146,6 +146,16 @@ class AccessHandler
 
         return $userUserGroups;
     }
+    
+   /**
+     * Returns all user groups.
+     *
+     * @return UserGroup[]
+     */
+    public function getUserGroups()
+    {
+        return $this->userGroupHandler->getUserGroups();
+    }
 
     /**
      * Checks if the current_user has access to the given post.


### PR DESCRIPTION
Hi, I added this method because I need it for a custom integration which automatically creates user groups for a list of users; without this I would need to re-create all groups each time, without any hope for reuse.
Maybe it's not the cleanest way, but followed what an older version of the plugin exposed.

Thanks