### PR TITLE
Update AccessHandler.php

### DIFF
--- a/src/Access/AccessHandler.php
+++ b/src/Access/AccessHandler.php
@@ -184,7 +184,7 @@ class AccessHandler
             } else {
                 $membership = $this->userGroupHandler->getUserGroupsForObject($objectType, $objectId);
                 $access = $membership === []
-                    || array_intersect_key($membership, $this->getUserUserGroupsForObjectAccess($isAdmin)) !== [];
+                    || ( array_intersect_key($membership, $this->getUserUserGroupsForObjectAccess($isAdmin)) !== [] && is_user_member_of_blog() );
             }
 
             $this->objectAccess[$admin][$objectType][$objectId] = $access;


### PR DESCRIPTION
In a multisite enviroment, 
without this fix, the user logged in the network (but not member of current blog because being removed from blog but not from his group) is able to see the protected contents