### PR TITLE
Ensure userId is int or bool

### DIFF
--- a/src/User/UserHandler.php
+++ b/src/User/UserHandler.php
@@ -141,6 +141,10 @@ class UserHandler
         $roles = $this->getUserRole($user);
         $rolesMap = array_flip($roles);
 
+        if( is_string($userId) ){
+            $userId = intval($userId);
+        }
+
         return (isset($rolesMap['administrator']) === true || $this->wordpress->isSuperAdmin($userId) === true);
     }
 }


### PR DESCRIPTION
In User/UserHandler userIsAdmin, the $userId can be int or string, but the Wrapper/Wordpress isSuperAdmin wait for bool or int.