### PR TITLE
nginx support: X-Accel-Redirect, Redis cache provider, and bug fixes

### DIFF
--- a/includes/language.php
+++ b/includes/language.php
@@ -150,6 +150,12 @@ define('TXT_UAM_FS_CACHE_METHOD_SERIALIZE', __('PHP serialize', 'user-access-man
 define('TXT_UAM_FS_CACHE_METHOD_IGBINARY', __('PHP igbinary (igbinary required)', 'user-access-manager'));
 define('TXT_UAM_FS_CACHE_METHOD_JSON', __('Json', 'user-access-manager'));
 define('TXT_UAM_FS_CACHE_METHOD_VAR_EXPORT', __('PHP var_export', 'user-access-manager'));
+define('TXT_UAM_REDISCACHEPROVIDER_SETTING', __('Redis cache', 'user-access-manager'));
+define('TXT_UAM_REDISCACHEPROVIDER_SETTING_DESC', __('This cache uses the WordPress object cache API with a persistent Redis backend.', 'user-access-manager'));
+define('TXT_UAM_REDIS_PREFIX', __('Key prefix', 'user-access-manager'));
+define('TXT_UAM_REDIS_PREFIX_DESC', __('Prefix added to every cache key to avoid collisions with other plugins.', 'user-access-manager'));
+define('TXT_UAM_REDIS_TTL', __('TTL (seconds)', 'user-access-manager'));
+define('TXT_UAM_REDIS_TTL_DESC', __('Cache entry expiration time in seconds. Use 0 for no expiration.', 'user-access-manager'));
 
 // --- Setting Page -> other settings ---
 define('TXT_UAM_OTHER_SETTING', __('Other settings', 'user-access-manager'));

--- a/includes/language.php
+++ b/includes/language.php
@@ -110,6 +110,7 @@ define('TXT_UAM_INLINE_FILES_DESC', __('These files (comma separated) will be sh
 define('TXT_UAM_DOWNLOAD_TYPE_NORMAL', __('Normal', 'user-access-manager'));
 define('TXT_UAM_DOWNLOAD_TYPE_FOPEN', __('fopen', 'user-access-manager'));
 define('TXT_UAM_DOWNLOAD_TYPE_XSENDFILE', __('XSendfile', 'user-access-manager'));
+define('TXT_UAM_DOWNLOAD_TYPE_XACCELREDIRECT', __('X-Accel-Redirect', 'user-access-manager'));
 
 // --- Setting Page -> editor settings ---
 define('TXT_UAM_AUTHOR_SETTING', __('Authors settings', 'user-access-manager'));

--- a/init.php
+++ b/init.php
@@ -87,7 +87,8 @@ function initUserAccessManger()
         $database,
         $objectHandler,
         $userHandler,
-        $userGroupFactory
+        $userGroupFactory,
+        $cache
     );
     $accessHandler = new AccessHandler(
         $wordpress,
@@ -95,7 +96,8 @@ function initUserAccessManger()
         $database,
         $objectHandler,
         $userHandler,
-        $userGroupHandler
+        $userGroupHandler,
+        $cache
     );
     $fileProtectionFactory = new FileProtectionFactory(
         $php,

--- a/languages/user-access-manager.pot
+++ b/languages/user-access-manager.pot
@@ -410,6 +410,10 @@ msgstr ""
 msgid "XSendfile"
 msgstr ""
 
+#: includes/language.php:113
+msgid "X-Accel-Redirect"
+msgstr ""
+
 #: includes/language.php:115
 msgid "Authors settings"
 msgstr ""

--- a/languages/user-access-manager.pot
+++ b/languages/user-access-manager.pot
@@ -1,0 +1,1209 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the user-access-manager package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: user-access-manager 2.3.11\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-01-26 10:22+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/Wrapper/Wordpress.php:747
+msgid "M j, Y @ H:i"
+msgstr ""
+
+#. //www.gnu.org/licenses/gpl-2.0.html  GNU General Public License, version 2
+#. * @version   SVN: $Id$
+#. * @link      http://wordpress.org/extend/plugins/user-access-manager/
+#.
+#. --- Error Messages ---
+#: includes/language.php:17
+#, php-format
+msgid ""
+"Sorry you need at least PHP version 7.2 to use the User Access Manager. Your "
+"current PHP version is %s. See <a href=\"https://github.com/GM-Alex/user-"
+"access-manager/wiki/Troubleshoot\">https://github.com/GM-Alex/user-access-"
+"manager/wiki/Troubleshoot</a> for more information."
+msgstr ""
+
+#: includes/language.php:18
+#, php-format
+msgid ""
+"Sorry you need at least WordPress version 3.0 to use the User Access "
+"Manager. Your current WordPress version is %s."
+msgstr ""
+
+#: includes/language.php:20
+#, php-format
+msgid ""
+"Please update the database of the User Access Manager. <a href=\"%s\">Click "
+"here to proceed</a>"
+msgstr ""
+
+#: includes/language.php:21
+#, php-format
+msgid "The following error occurred: %s"
+msgstr ""
+
+#: includes/language.php:24 includes/language.php:95 includes/language.php:99
+msgid "All"
+msgstr ""
+
+#: includes/language.php:25
+msgid "All users (group and none group users)"
+msgstr ""
+
+#: includes/language.php:26
+msgid "Only group users"
+msgstr ""
+
+#: includes/language.php:27
+msgid "None"
+msgstr ""
+
+#: includes/language.php:28
+msgid "Yes"
+msgstr ""
+
+#: includes/language.php:29
+msgid "No"
+msgstr ""
+
+#: includes/language.php:33
+msgid "Settings"
+msgstr ""
+
+#: includes/language.php:34 includes/language.php:85
+msgid "Default"
+msgstr ""
+
+#: includes/language.php:37 includes/language.php:130
+msgid "Object type"
+msgstr ""
+
+#: includes/language.php:38
+msgid "Post type settings"
+msgstr ""
+
+#: includes/language.php:39
+msgid "Taxonomies settings"
+msgstr ""
+
+#: includes/language.php:40
+msgid "Default settings"
+msgstr ""
+
+#: includes/language.php:41
+msgid "Set up the behaviour if the object is locked"
+msgstr ""
+
+#: includes/language.php:42
+msgid "Title"
+msgstr ""
+
+#: includes/language.php:43
+msgid "Displayed text as title if user has no access"
+msgstr ""
+
+#: includes/language.php:44
+msgid "Hide title"
+msgstr ""
+
+#: includes/language.php:45
+msgid ""
+"Selecting \"Yes\" will show the text which is defined at \"Title\" if user "
+"has no access."
+msgstr ""
+
+#: includes/language.php:46
+msgid "Content"
+msgstr ""
+
+#: includes/language.php:47 includes/language.php:67
+#, php-format
+msgid ""
+"Content displayed if user has no access. You can add a login-form by adding "
+"the keyword <strong>[LOGIN_FORM]</strong>. This form will be shown on single "
+"%s, otherwise a link will be shown."
+msgstr ""
+
+#: includes/language.php:48
+msgid "Hide complete"
+msgstr ""
+
+#: includes/language.php:49 includes/language.php:69
+#, php-format
+msgid "Selecting \"Yes\" will hide %s if the user has no access."
+msgstr ""
+
+#: includes/language.php:50
+msgid "Comment text"
+msgstr ""
+
+#: includes/language.php:51
+msgid "Displayed text as comment text if user has no access"
+msgstr ""
+
+#: includes/language.php:52
+msgid "Hide comments"
+msgstr ""
+
+#: includes/language.php:53 includes/language.php:73
+#, php-format
+msgid ""
+"Selecting \"Yes\" will show the text which is defined at \"%s comment text\" "
+"if user has no access."
+msgstr ""
+
+#: includes/language.php:54
+msgid "Lock comments"
+msgstr ""
+
+#: includes/language.php:55
+msgid "Selecting \"yes\" allows users to comment even if the content is locked"
+msgstr ""
+
+#: includes/language.php:56
+msgid "Show content before &lt;!--more--&gt; tag"
+msgstr ""
+
+#: includes/language.php:57
+#, php-format
+msgid ""
+"Shows the content before the &lt;!--more--&gt; tag and after that the "
+"defined text at \"%s content\". If no &lt;!--more--&gt; is set the defined "
+"text at \"%s content\" will be shown."
+msgstr ""
+
+#: includes/language.php:58
+#, php-format
+msgid "Use default settings for %s"
+msgstr ""
+
+#: includes/language.php:59
+msgid "If selected the settings form the default type will be used."
+msgstr ""
+
+#: includes/language.php:60
+#, php-format
+msgid "%s settings"
+msgstr ""
+
+#: includes/language.php:61
+#, php-format
+msgid "Set up the behaviour if the %s is locked"
+msgstr ""
+
+#: includes/language.php:62
+#, php-format
+msgid "%s title"
+msgstr ""
+
+#: includes/language.php:63
+#, php-format
+msgid "Displayed text as %s title if user has no access"
+msgstr ""
+
+#: includes/language.php:64
+#, php-format
+msgid "Hide %s title"
+msgstr ""
+
+#: includes/language.php:65
+#, php-format
+msgid ""
+"Selecting \"Yes\" will show the text which is defined at \"%s title\" if "
+"user has no access."
+msgstr ""
+
+#: includes/language.php:66
+#, php-format
+msgid "%s content"
+msgstr ""
+
+#: includes/language.php:68
+#, php-format
+msgid "Hide complete %s"
+msgstr ""
+
+#: includes/language.php:70
+#, php-format
+msgid "%s comment text"
+msgstr ""
+
+#: includes/language.php:71
+#, php-format
+msgid "Displayed text as %s comment text if user has no access"
+msgstr ""
+
+#: includes/language.php:72
+#, php-format
+msgid "Hide %s comments"
+msgstr ""
+
+#: includes/language.php:74
+#, php-format
+msgid "Lock %s comments"
+msgstr ""
+
+#: includes/language.php:75
+#, php-format
+msgid "Selecting \"yes\" also locks comments on locked %s"
+msgstr ""
+
+#: includes/language.php:76
+#, php-format
+msgid "Show %s content before &lt;!--more--&gt; tag"
+msgstr ""
+
+#: includes/language.php:77
+#, php-format
+msgid ""
+"Shows the %s content before the &lt;!--more--&gt; tag and after that the "
+"defined text at \"%s content\". If no &lt;!--more--&gt; is set the defined "
+"text at \"%s content\" will shown."
+msgstr ""
+
+#: includes/language.php:80
+msgid "File settings"
+msgstr ""
+
+#: includes/language.php:81
+msgid "Set up the behaviour of files"
+msgstr ""
+
+#: includes/language.php:82
+msgid "Lock files"
+msgstr ""
+
+#: includes/language.php:83
+msgid "No access image type"
+msgstr ""
+
+#: includes/language.php:84
+msgid "If you choose \"Custom\", please specify the full path to your image."
+msgstr ""
+
+#: includes/language.php:86 includes/language.php:96
+msgid "Custom"
+msgstr ""
+
+#: includes/language.php:87
+msgid "Use custom file handling file"
+msgstr ""
+
+#: includes/language.php:88
+msgid "Selecting \"Yes\" will allow you to use your own config file."
+msgstr ""
+
+#: includes/language.php:89
+msgid "Custom file handling file"
+msgstr ""
+
+#: includes/language.php:90
+msgid ""
+"Edit this content if you are using the custom file handling file setting."
+msgstr ""
+
+#: includes/language.php:91
+msgid ""
+"If you select \"Yes\" all files will locked by a .htaccess file and only "
+"users with access can download files. <br/><strong style=\"color:red;"
+"\">Note: If you activate this option the plugin will overwrite a '.htaccess' "
+"file at the upload folder, if you use already one to protect your files. "
+"Also if you have no permalinks activated your upload dir will protect by a '."
+"htaccess' with a random password and all old media files insert in a "
+"previous post/page will not work anymore. You have to update your posts/"
+"pages (not necessary if you have permalinks activated).</strong>"
+msgstr ""
+
+#: includes/language.php:92
+msgid "Locked directory type"
+msgstr ""
+
+#: includes/language.php:93
+msgid ""
+"\"WordPress\" will only lock files handled by the WordPress media manager "
+"(recommended), \"All\" will lock all files at the upload directory, "
+"\"Custom\" will use a custom string."
+msgstr ""
+
+#: includes/language.php:94
+msgid "WordPress"
+msgstr ""
+
+#: includes/language.php:97
+msgid "Locked file types"
+msgstr ""
+
+#: includes/language.php:98
+msgid ""
+"Lock all files, type in file types which you will lock if the post/page is "
+"locked or define file types which will not be locked. <strong>Note:</strong> "
+"If you have no problems use all to get the maximum security."
+msgstr ""
+
+#: includes/language.php:100
+msgid "File types to lock: "
+msgstr ""
+
+#: includes/language.php:101
+msgid "File types not to lock: "
+msgstr ""
+
+#: includes/language.php:102
+msgid ".htaccess password"
+msgstr ""
+
+#: includes/language.php:103
+msgid ""
+"Set up the password for the .htaccess access. This password is only needed "
+"if you need a direct access to your files."
+msgstr ""
+
+#: includes/language.php:104
+msgid "Use a random generated password."
+msgstr ""
+
+#: includes/language.php:105
+msgid "Use the password of the current logged in admin."
+msgstr ""
+
+#: includes/language.php:106
+msgid "Download type"
+msgstr ""
+
+#: includes/language.php:107
+msgid ""
+"Selecting the type for downloading. <strong>Note:</strong> For using fopen "
+"you need \"safe_mode = off\"."
+msgstr ""
+
+#: includes/language.php:108
+msgid "Inline file types"
+msgstr ""
+
+#: includes/language.php:109
+msgid ""
+"These files (comma separated) will be shown within the browser window and "
+"not downloaded (images are always inline)."
+msgstr ""
+
+#: includes/language.php:110
+msgid "Normal"
+msgstr ""
+
+#: includes/language.php:111
+msgid "fopen"
+msgstr ""
+
+#: includes/language.php:112
+msgid "XSendfile"
+msgstr ""
+
+#: includes/language.php:115
+msgid "Authors settings"
+msgstr ""
+
+#: includes/language.php:116
+msgid "Here you will find the settings for authors"
+msgstr ""
+
+#: includes/language.php:117
+msgid "Authors always has access to own posts/pages"
+msgstr ""
+
+#: includes/language.php:118
+msgid ""
+"If \"Yes\" is selected author will always have full access to their own "
+"posts or pages."
+msgstr ""
+
+#: includes/language.php:119
+msgid "Authors can add content to their own groups"
+msgstr ""
+
+#: includes/language.php:120
+msgid ""
+"If \"Yes\" is selected author are able to restrict the content by adding it "
+"to their groups."
+msgstr ""
+
+#: includes/language.php:121
+msgid "Minimum user role with full access"
+msgstr ""
+
+#: includes/language.php:122
+msgid "All user with a role equal or higher to this has full access."
+msgstr ""
+
+#: includes/language.php:123
+msgid "Administrator"
+msgstr ""
+
+#: includes/language.php:124
+msgid "Editor"
+msgstr ""
+
+#: includes/language.php:125
+msgid "Author"
+msgstr ""
+
+#: includes/language.php:126
+msgid "Contributor"
+msgstr ""
+
+#: includes/language.php:127
+msgid "Subscriber"
+msgstr ""
+
+#: includes/language.php:131
+msgid "Taxonomy settings"
+msgstr ""
+
+#: includes/language.php:132
+msgid "Set up the behaviour if a taxonomy is locked"
+msgstr ""
+
+#: includes/language.php:133
+msgid "Hide empty"
+msgstr ""
+
+#: includes/language.php:134
+msgid ""
+"Selecting \"Yes\" will hide empty taxonomies which are containing only empty "
+"childes or no childes."
+msgstr ""
+
+#: includes/language.php:135
+#, php-format
+msgid "Hide empty %s"
+msgstr ""
+
+#: includes/language.php:136
+#, php-format
+msgid ""
+"Selecting \"Yes\" will hide empty %s which are containing only empty childes "
+"or no childes."
+msgstr ""
+
+#: includes/language.php:139
+msgid "Active caching method"
+msgstr ""
+
+#: includes/language.php:140
+msgid "Cache settings"
+msgstr ""
+
+#: includes/language.php:141
+msgid "Cache deactivated"
+msgstr ""
+
+#: includes/language.php:142
+msgid "The cache is currently deactivated."
+msgstr ""
+
+#: includes/language.php:143
+msgid "File system cache"
+msgstr ""
+
+#: includes/language.php:144
+msgid "This cache uses the file system for the cache."
+msgstr ""
+
+#: includes/language.php:145
+msgid "Path"
+msgstr ""
+
+#: includes/language.php:146
+msgid "File system path to store the cache files."
+msgstr ""
+
+#: includes/language.php:147
+msgid "Method"
+msgstr ""
+
+#: includes/language.php:148
+msgid "The caching method which should be used."
+msgstr ""
+
+#: includes/language.php:149
+msgid "PHP serialize"
+msgstr ""
+
+#: includes/language.php:150
+msgid "PHP igbinary (igbinary required)"
+msgstr ""
+
+#: includes/language.php:151
+msgid "Json"
+msgstr ""
+
+#: includes/language.php:152
+msgid "PHP var_export"
+msgstr ""
+
+#: includes/language.php:153
+msgid "Redis cache"
+msgstr ""
+
+#: includes/language.php:154
+msgid "This cache uses the WordPress object cache API with a persistent Redis backend."
+msgstr ""
+
+#: includes/language.php:155
+msgid "Key prefix"
+msgstr ""
+
+#: includes/language.php:156
+msgid "Prefix added to every cache key to avoid collisions with other plugins."
+msgstr ""
+
+#: includes/language.php:157
+msgid "TTL (seconds)"
+msgstr ""
+
+#: includes/language.php:158
+msgid "Cache entry expiration time in seconds. Use 0 for no expiration."
+msgstr ""
+
+#: includes/language.php:155
+msgid "Other settings"
+msgstr ""
+
+#: includes/language.php:156
+msgid "Here you will find all other settings"
+msgstr ""
+
+#: includes/language.php:157
+msgid "Protect Feed"
+msgstr ""
+
+#: includes/language.php:158
+msgid "Selecting \"Yes\" will also protect your feed entries."
+msgstr ""
+
+#: includes/language.php:159
+msgid "Redirect user"
+msgstr ""
+
+#: includes/language.php:160
+msgid "Setup what happen if a user visit a post/page with no access."
+msgstr ""
+
+#: includes/language.php:161
+msgid "To blog start page"
+msgstr ""
+
+#: includes/language.php:162
+msgid "To login page (wp-admin)"
+msgstr ""
+
+#: includes/language.php:163
+msgid "Custom page: "
+msgstr ""
+
+#: includes/language.php:164
+msgid "Custom URL: "
+msgstr ""
+
+#: includes/language.php:165
+msgid "Lock recursive"
+msgstr ""
+
+#: includes/language.php:166
+msgid ""
+"Selecting \"Yes\" will lock all child posts/pages of a post/page if a user "
+"has no access to the parent page. Note: Setting this option to \"No\" could "
+"result in display errors relating to the hierarchy."
+msgstr ""
+
+#: includes/language.php:167
+msgid "Admin hint text"
+msgstr ""
+
+#: includes/language.php:168
+msgid "The text which will shown behind the post/page."
+msgstr ""
+
+#: includes/language.php:169
+msgid "Show admin hint at Posts"
+msgstr ""
+
+#: includes/language.php:170
+#, php-format
+msgid ""
+"Selecting \"Yes\" will show the defined text at \"%s\" behind the post/page "
+"to a logged in admin to show him which posts/pages are locked if he visits "
+"his blog."
+msgstr ""
+
+#: includes/language.php:171
+msgid "Show assigned groups"
+msgstr ""
+
+#: includes/language.php:172
+msgid "Show assigned groups next to the edit link"
+msgstr ""
+
+#: includes/language.php:173
+msgid "Hide edit link on no access"
+msgstr ""
+
+#: includes/language.php:174
+msgid "Hides the edit link if the user has no write access."
+msgstr ""
+
+#: includes/language.php:175
+msgid "Extra IP header"
+msgstr ""
+
+#: includes/language.php:176
+msgid ""
+"Use this header for the user IP address if you are using a proxy. A valid "
+"value is for example HTTP_X_REAL_IP."
+msgstr ""
+
+#: includes/language.php:179
+msgid "No rights!"
+msgstr ""
+
+#: includes/language.php:180
+msgid "Sorry you have no rights to view this entry!"
+msgstr ""
+
+#: includes/language.php:181
+msgid "Sorry no rights to view comments!"
+msgstr ""
+
+#: includes/language.php:184
+msgid "Update settings"
+msgstr ""
+
+#: includes/language.php:185
+msgid "Settings updated."
+msgstr ""
+
+#: includes/language.php:189
+msgid "Manage user groups"
+msgstr ""
+
+#: includes/language.php:190
+msgid "User groups"
+msgstr ""
+
+#: includes/language.php:191
+msgid "Role affiliation"
+msgstr ""
+
+#: includes/language.php:192
+msgid "Name"
+msgstr ""
+
+#: includes/language.php:193
+msgid "Description"
+msgstr ""
+
+#: includes/language.php:194 includes/language.php:207
+msgid "Read access"
+msgstr ""
+
+#: includes/language.php:195 includes/language.php:209
+msgid "Write access"
+msgstr ""
+
+#: includes/language.php:196
+msgid "Delete"
+msgstr ""
+
+#: includes/language.php:197
+msgid "Update group"
+msgstr ""
+
+#: includes/language.php:198
+msgid "Add"
+msgstr ""
+
+#: includes/language.php:199
+msgid "Add user group"
+msgstr ""
+
+#: includes/language.php:200
+msgid "Edit user group"
+msgstr ""
+
+#: includes/language.php:201
+msgid "User group name"
+msgstr ""
+
+#: includes/language.php:202
+msgid "The name is used to identify the access user group."
+msgstr ""
+
+#: includes/language.php:203
+msgid "User group description"
+msgstr ""
+
+#: includes/language.php:204
+msgid "The description of the group."
+msgstr ""
+
+#: includes/language.php:205 includes/language.php:215
+msgid "IP range"
+msgstr ""
+
+#: includes/language.php:206
+msgid ""
+"Type in the IP ranges of users which are join these groups by their IP "
+"address without login. Set ranges like \"BEGIN\"-\"END\", separate ranges by "
+"using \";\", single IPs are also allowed. Example: "
+"192.168.0.1-192.168.0.10;192.168.0.20-192.168.0.30"
+msgstr ""
+
+#: includes/language.php:208
+msgid "The read access."
+msgstr ""
+
+#: includes/language.php:210
+msgid "The write access."
+msgstr ""
+
+#: includes/language.php:211
+msgid "Group was added successfully."
+msgstr ""
+
+#: includes/language.php:212
+msgid "Group name can not be empty."
+msgstr ""
+
+#: includes/language.php:213
+msgid "Group(s) was deleted successfully."
+msgstr ""
+
+#: includes/language.php:214
+msgid "User group edit successfully."
+msgstr ""
+
+#: includes/language.php:216
+msgid "Default user groups"
+msgstr ""
+
+#: includes/language.php:217
+msgid "Default user groups for object type"
+msgstr ""
+
+#: includes/language.php:218
+msgid "Update default user groups"
+msgstr ""
+
+#: includes/language.php:219
+msgid "Default user groups updated"
+msgstr ""
+
+#: includes/language.php:220
+msgid "Post Type"
+msgstr ""
+
+#: includes/language.php:221
+msgid "Taxonomy"
+msgstr ""
+
+#: includes/language.php:225
+msgid "Setup"
+msgstr ""
+
+#: includes/language.php:226
+msgid "Danger Zone"
+msgstr ""
+
+#: includes/language.php:227
+msgid "Reset User Access Manager"
+msgstr ""
+
+#: includes/language.php:228
+msgid "Type 'reset' in the input field to reset the User Access Manager."
+msgstr ""
+
+#: includes/language.php:229
+msgid ""
+"Warning: The reset of the User Access Manager can not be undone. All "
+"settings and user groups will permanently lost."
+msgstr ""
+
+#: includes/language.php:230
+msgid "reset now"
+msgstr ""
+
+#: includes/language.php:231
+msgid "Update User Access Manager database"
+msgstr ""
+
+#: includes/language.php:232
+msgid ""
+"Updates the database of the User Access Manager. Please backup your database "
+"before you perform the update."
+msgstr ""
+
+#: includes/language.php:233
+msgid "update now"
+msgstr ""
+
+#: includes/language.php:234
+msgid "User Access Manager was reset successfully"
+msgstr ""
+
+#: includes/language.php:235
+msgid "User Access Manager database was updated successfully"
+msgstr ""
+
+#: includes/language.php:236
+msgid "Failure on User Access Manager database update"
+msgstr ""
+
+#: includes/language.php:237
+msgid "Update current blog"
+msgstr ""
+
+#: includes/language.php:238
+msgid "Update network wide"
+msgstr ""
+
+#: includes/language.php:239
+msgid "Backup the uam database tables"
+msgstr ""
+
+#: includes/language.php:240
+msgid "Repair the database"
+msgstr ""
+
+#: includes/language.php:241
+msgid "Try to repair the database."
+msgstr ""
+
+#: includes/language.php:242
+msgid "repair now"
+msgstr ""
+
+#: includes/language.php:243
+msgid "Database repair successfull"
+msgstr ""
+
+#: includes/language.php:244
+msgid ""
+"<b style=\"color:red;\">Your UAM database seems broken. You should try to "
+"repair it.</b>"
+msgstr ""
+
+#: includes/language.php:245
+msgid ""
+"<b style=\"color:green;\">Your UAM database seems to be in good condition.</"
+"b>"
+msgstr ""
+
+#: includes/language.php:246
+msgid "Revert the database"
+msgstr ""
+
+#: includes/language.php:247
+msgid ""
+"Choose a backup to revert the database to this user access manager database "
+"version. <b>Note: The user access manager database version differs from the "
+"user access manager version.</b>"
+msgstr ""
+
+#: includes/language.php:248
+msgid "revert now"
+msgstr ""
+
+#: includes/language.php:249
+msgid "Revert successfull"
+msgstr ""
+
+#: includes/language.php:250
+msgid "Delete a database backup"
+msgstr ""
+
+#: includes/language.php:251
+msgid "Choose a backup to delete. <b>Note: That cannot be undone.</b>"
+msgstr ""
+
+#: includes/language.php:252
+msgid "delete now"
+msgstr ""
+
+#: includes/language.php:253
+msgid "Backup deleted successfully"
+msgstr ""
+
+#: includes/language.php:257
+msgid "About"
+msgstr ""
+
+#: includes/language.php:260
+msgid "How to support me?"
+msgstr ""
+
+#: includes/language.php:261
+msgid "Help me to improve the plugin"
+msgstr ""
+
+#: includes/language.php:262
+msgid ""
+"Send me bug reports, bug fixes, pull requests or your ideas. See: <a "
+"href=\"https://github.com/GM-Alex/user-access-manager\">https://github.com/"
+"GM-Alex/user-access-manager</a>"
+msgstr ""
+
+#: includes/language.php:263
+msgid "Create a translation of the plugin"
+msgstr ""
+
+#: includes/language.php:264
+msgid ""
+"Give other users more comfort help me to translate it to all languages. See: "
+"<a href=\"https://translate.wordpress.org/projects/wp-plugins/user-access-"
+"manager\">https://translate.wordpress.org/projects/wp-plugins/user-access-"
+"manager</a>"
+msgstr ""
+
+#: includes/language.php:265
+msgid "Donate via PayPal"
+msgstr ""
+
+#: includes/language.php:266
+msgid "Support me on Steady"
+msgstr ""
+
+#: includes/language.php:267
+msgid "Spread the word"
+msgstr ""
+
+#: includes/language.php:268
+msgid ""
+"Write about the plugin and place a link to the plugin in your blog/website."
+msgstr ""
+
+#: includes/language.php:271
+msgid "Thanks"
+msgstr ""
+
+#: includes/language.php:272
+msgid "Be the first one supporting me on steady!"
+msgstr ""
+
+#: includes/language.php:273
+msgid "Top supporters"
+msgstr ""
+
+#: includes/language.php:274
+msgid "Supporters"
+msgstr ""
+
+#: includes/language.php:275
+msgid "Special thanks"
+msgstr ""
+
+#: includes/language.php:276
+msgid "My wife for giving me the time to develop this plugin"
+msgstr ""
+
+#: includes/language.php:277
+msgid "All testers and all others I forgot"
+msgstr ""
+
+#: includes/language.php:281
+msgid "Access"
+msgstr ""
+
+#: includes/language.php:282
+msgid "UAM User Groups"
+msgstr ""
+
+#: includes/language.php:286
+msgid "Full access"
+msgstr ""
+
+#: includes/language.php:287
+#, php-format
+msgid "Member of %s other user groups"
+msgstr ""
+
+#: includes/language.php:288
+msgid ""
+"<strong>Note:</strong> An administrator has always access to all posts/pages."
+msgstr ""
+
+#: includes/language.php:289
+msgid "Please create a user group first."
+msgstr ""
+
+#: includes/language.php:290
+msgid "No user group available."
+msgstr ""
+
+#: includes/language.php:291
+msgid "No rights"
+msgstr ""
+
+#: includes/language.php:292
+msgid "You have no rights to access this content."
+msgstr ""
+
+#: includes/language.php:293
+msgid "User Groups"
+msgstr ""
+
+#: includes/language.php:294
+msgid "Set up user groups"
+msgstr ""
+
+#: includes/language.php:295
+msgid "Nonce error"
+msgstr ""
+
+#: includes/language.php:296
+msgid "Sorry, your nonce did not verify."
+msgstr ""
+
+#: includes/language.php:299
+msgid "Info"
+msgstr ""
+
+#: includes/language.php:300
+msgid "Group info"
+msgstr ""
+
+#: includes/language.php:301
+#, php-format
+msgid "Group membership given by %s"
+msgstr ""
+
+#: includes/language.php:302
+msgid "Assigned groups"
+msgstr ""
+
+#: includes/language.php:303 includes/language.php:337
+msgid "Role"
+msgstr ""
+
+#: includes/language.php:304 includes/language.php:336
+msgid "User"
+msgstr ""
+
+#: includes/language.php:305
+msgid "Term"
+msgstr ""
+
+#: includes/language.php:306
+msgid "Post"
+msgstr ""
+
+#: includes/language.php:310
+msgid "Opening file info database failed."
+msgstr ""
+
+#: includes/language.php:311
+msgid "Error: File not found."
+msgstr ""
+
+#: includes/language.php:312
+msgid "The file you are looking for wasn't found."
+msgstr ""
+
+#: includes/language.php:316
+msgid "Username"
+msgstr ""
+
+#: includes/language.php:317
+msgid "Password"
+msgstr ""
+
+#: includes/language.php:318
+msgid "Login"
+msgstr ""
+
+#: includes/language.php:319
+msgid "Logout"
+msgstr ""
+
+#: includes/language.php:320
+#, php-format
+msgid "Welcome, %s!"
+msgstr ""
+
+#: includes/language.php:321
+msgid "Register"
+msgstr ""
+
+#: includes/language.php:322
+msgid "Lost your password?"
+msgstr ""
+
+#: includes/language.php:323
+msgid "Password Lost and Found"
+msgstr ""
+
+#: includes/language.php:324
+msgid "Remember me"
+msgstr ""
+
+#: includes/language.php:328
+msgid "Setup time based group assignment"
+msgstr ""
+
+#: includes/language.php:329 includes/language.php:331
+msgid "From"
+msgstr ""
+
+#: includes/language.php:330 includes/language.php:332
+msgid "To"
+msgstr ""
+
+#: includes/language.php:338
+msgid "Not logged in users"
+msgstr ""
+
+#: includes/language.php:339
+msgid "Add dynamic groups"
+msgstr ""
+
+#: includes/language.php:342
+msgid "UAM login widget"
+msgstr ""
+
+#: includes/language.php:343
+msgid "User Access Manager login widget for users."
+msgstr ""
+
+#: includes/language.php:346
+msgid "Get User Access Manager Pro!"
+msgstr ""
+
+#: includes/language.php:347
+msgid ""
+"You want all the features? Guess what? You are already using the Pro "
+"version, because there is none. So it would be nice if you support me and "
+"become a supporter at steady, <b>especially if you use the plugin on a "
+"commercial site</b>. This will keep me motivated to do the support and spend "
+"my free time for the plugin. ;)"
+msgstr ""
+
+#: includes/language.php:348
+msgid "Need help?"
+msgstr ""
+
+#: includes/language.php:349
+msgid ""
+"You got stuck using the User access manager? See <a href=\"https://github."
+"com/GM-Alex/user-access-manager/wiki\">https://github.com/GM-Alex/user-"
+"access-manager/wiki</a>"
+msgstr ""

--- a/src/Access/AccessHandler.php
+++ b/src/Access/AccessHandler.php
@@ -37,8 +37,10 @@ class AccessHandler
             && $this->objectHandler->isPostType($objectType)
         ) {
             $post = $this->objectHandler->getPost($objectId);
+            $currentUserId = $this->wordpress->getCurrentUser()->ID;
             return $post !== false
-                && $this->wordpress->getCurrentUser()->ID === (int) $post->post_author;
+                && $currentUserId !== 0
+                && $currentUserId === (int) $post->post_author;
         }
 
         return false;

--- a/src/Access/AccessHandler.php
+++ b/src/Access/AccessHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UserAccessManager\Access;
 
 use Exception;
+use UserAccessManager\Cache\Cache;
 use UserAccessManager\Config\MainConfig;
 use UserAccessManager\Database\Database;
 use UserAccessManager\Object\ObjectHandler;
@@ -27,8 +28,24 @@ class AccessHandler
         private Database $database,
         private ObjectHandler $objectHandler,
         private UserHandler $userHandler,
-        private UserGroupHandler $userGroupHandler
+        private UserGroupHandler $userGroupHandler,
+        private Cache $cache
     ) {
+    }
+
+    /**
+     * Builds a cache key for a specific access decision.
+     *
+     * The key encodes the user ID, admin flag, object type and object ID so
+     * that results for different users and objects are stored independently.
+     */
+    private function buildAccessCacheKey(
+        int $userId,
+        bool $isAdmin,
+        ?string $objectType,
+        int|string|null $objectId
+    ): string {
+        return 'uam_access_' . $userId . '_' . (int) $isAdmin . '_' . $objectType . '_' . $objectId;
     }
 
     private function hasAuthorAccess(string $objectType, int|string|null $objectId): bool
@@ -79,22 +96,33 @@ class AccessHandler
         $isAdmin = $this->isAdmin($isAdmin);
 
         if (isset($this->objectAccess[$isAdmin][$objectType][$objectId]) === false) {
-            if ($this->objectHandler->isValidObjectType($objectType) === false
-                || $this->userHandler->checkUserAccess(UserHandler::MANAGE_USER_GROUPS_CAPABILITY) === true
-                || $this->hasAuthorAccess($objectType, $objectId) === true
-            ) {
-                $access = true;
+            $userId = $this->wordpress->getCurrentUser()->ID;
+            $cacheKey = $this->buildAccessCacheKey($userId, $isAdmin, $objectType, $objectId);
+            $cached = $this->cache->get($cacheKey);
+
+            if ($cached !== null) {
+                // Warm the in-memory cache from the persistent cache so subsequent
+                // calls within the same request do not hit the cache provider again.
+                $this->objectAccess[$isAdmin][$objectType][$objectId] = (bool) $cached;
             } else {
-                $membership = $this->userGroupHandler->getUserGroupsForObject($objectType, $objectId);
-                $access = $membership === []
-                    || array_intersect_key($membership, $this->getUserUserGroupsForObjectAccess($isAdmin)) !== [];
+                if ($this->objectHandler->isValidObjectType($objectType) === false
+                    || $this->userHandler->checkUserAccess(UserHandler::MANAGE_USER_GROUPS_CAPABILITY) === true
+                    || $this->hasAuthorAccess($objectType, $objectId) === true
+                ) {
+                    $access = true;
+                } else {
+                    $membership = $this->userGroupHandler->getUserGroupsForObject($objectType, $objectId);
+                    $access = $membership === []
+                        || array_intersect_key($membership, $this->getUserUserGroupsForObjectAccess($isAdmin)) !== [];
 
-                if ($access && $this->wordpress->isUserLoggedIn() && $this->wordpress->isMultiSite()) {
-                    $access = $this->wordpress->isUserMemberOfBlog();
+                    if ($access && $this->wordpress->isUserLoggedIn() && $this->wordpress->isMultiSite()) {
+                        $access = $this->wordpress->isUserMemberOfBlog();
+                    }
                 }
-            }
 
-            $this->objectAccess[$isAdmin][$objectType][$objectId] = $access;
+                $this->objectAccess[$isAdmin][$objectType][$objectId] = $access;
+                $this->cache->add($cacheKey, $access);
+            }
         }
 
         return $this->objectAccess[$isAdmin][$objectType][$objectId];

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -84,10 +84,13 @@ class Cache
     public function getRegisteredCacheProviders(): array
     {
         $fileSystemCacheProvider = $this->cacheProviderFactory->createFileSystemCacheProvider();
+        $providers = [$fileSystemCacheProvider->getId() => $fileSystemCacheProvider];
 
-        return $this->wordpress->applyFilters(
-            'uam_registered_cache_handlers',
-            [$fileSystemCacheProvider->getId() => $fileSystemCacheProvider]
-        );
+        if (wp_using_ext_object_cache() === true) {
+            $redisCacheProvider = $this->cacheProviderFactory->createRedisCacheProvider();
+            $providers[$redisCacheProvider->getId()] = $redisCacheProvider;
+        }
+
+        return $this->wordpress->applyFilters('uam_registered_cache_handlers', $providers);
     }
 }

--- a/src/Cache/CacheProviderFactory.php
+++ b/src/Cache/CacheProviderFactory.php
@@ -34,4 +34,15 @@ class CacheProviderFactory
             $this->configParameterFactory
         );
     }
+
+    /**
+     * Creates a RedisCacheProvider object.
+     */
+    public function createRedisCacheProvider(): RedisCacheProvider
+    {
+        return new RedisCacheProvider(
+            $this->configFactory,
+            $this->configParameterFactory
+        );
+    }
 }

--- a/src/Cache/RedisCacheProvider.php
+++ b/src/Cache/RedisCacheProvider.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UserAccessManager\Cache;
+
+use UserAccessManager\Config\Config;
+use UserAccessManager\Config\ConfigFactory;
+use UserAccessManager\Config\ConfigParameterFactory;
+
+/**
+ * Cache provider that stores UAM cache data via the WordPress object cache API.
+ *
+ * When a persistent object cache backend (e.g. Redis via the Redis Object Cache
+ * drop-in) is active, cache entries survive across requests. Without a persistent
+ * backend WordPress falls back to an in-memory store that is discarded at the end
+ * of each request — in that case the FileSystemCacheProvider is a better choice.
+ *
+ * This provider is only registered when wp_using_ext_object_cache() returns true,
+ * so it will never appear as an option unless a persistent backend is installed.
+ */
+class RedisCacheProvider implements CacheProviderInterface
+{
+    /** Unique identifier used to select this provider in UAM settings. */
+    const ID = 'RedisCacheProvider';
+
+    /** WordPress option key under which this provider's configuration is stored. */
+    const CONFIG_KEY = 'uam_redis_cache_provider';
+
+    /** Configuration parameter: key prefix added to every cache entry. */
+    const CONFIG_PREFIX = 'redis_prefix';
+
+    /** Configuration parameter: TTL in seconds (0 = no expiration). */
+    const CONFIG_TTL = 'redis_ttl';
+
+    /** Default cache key prefix — avoids collisions with other plugins. */
+    const DEFAULT_PREFIX = 'uam_cache';
+
+    /** Default TTL: entries never expire unless explicitly invalidated. */
+    const DEFAULT_TTL = 0;
+
+    /** @var Config|null Lazily initialised configuration object. */
+    private ?Config $config = null;
+
+    /**
+     * @param ConfigFactory          $configFactory          Creates Config instances from WP options.
+     * @param ConfigParameterFactory $configParameterFactory Creates individual config parameter objects.
+     */
+    public function __construct(
+        private ConfigFactory $configFactory,
+        private ConfigParameterFactory $configParameterFactory
+    ) {
+    }
+
+    /**
+     * Returns the unique identifier for this cache provider.
+     *
+     * @return string Provider ID used in UAM settings and provider registry.
+     */
+    public function getId(): string
+    {
+        return self::ID;
+    }
+
+    /**
+     * Initialises the cache provider.
+     *
+     * No setup is required — the WordPress object cache is already bootstrapped
+     * before plugins are loaded.
+     */
+    public function init(): void
+    {
+        // WordPress object cache is already set up — nothing to initialise here.
+    }
+
+    /**
+     * Returns the configuration object for this provider, creating it on first call.
+     *
+     * Exposes two settings in the UAM cache settings panel:
+     *   - redis_prefix : string prefix prepended to every cache key
+     *   - redis_ttl    : expiration time in seconds (0 = never expire)
+     *
+     * @return Config Provider configuration.
+     */
+    public function getConfig(): Config
+    {
+        if ($this->config === null) {
+            $this->config = $this->configFactory->createConfig(self::CONFIG_KEY);
+
+            $configParameters = [
+                self::CONFIG_PREFIX => $this->configParameterFactory->createStringConfigParameter(
+                    self::CONFIG_PREFIX,
+                    self::DEFAULT_PREFIX
+                ),
+                self::CONFIG_TTL => $this->configParameterFactory->createStringConfigParameter(
+                    self::CONFIG_TTL,
+                    (string) self::DEFAULT_TTL
+                ),
+            ];
+
+            $this->config->setDefaultConfigParameters($configParameters);
+        }
+
+        return $this->config;
+    }
+
+    /**
+     * Returns the configured key prefix.
+     *
+     * Falls back to DEFAULT_PREFIX if config has not been initialised yet.
+     *
+     * @return string Cache key prefix.
+     */
+    private function getPrefix(): string
+    {
+        return (string) ($this->config?->getParameterValue(self::CONFIG_PREFIX) ?? self::DEFAULT_PREFIX);
+    }
+
+    /**
+     * Returns the configured TTL in seconds.
+     *
+     * Falls back to DEFAULT_TTL (no expiration) if config has not been initialised yet.
+     *
+     * @return int TTL in seconds; 0 means no expiration.
+     */
+    private function getTtl(): int
+    {
+        return (int) ($this->config?->getParameterValue(self::CONFIG_TTL) ?? self::DEFAULT_TTL);
+    }
+
+    /**
+     * Builds a namespaced cache key by combining the prefix and the raw key.
+     *
+     * Using a prefix prevents collisions with other plugins that share the same
+     * WordPress object cache group or global key namespace.
+     *
+     * @param  string $key Raw cache key supplied by UAM.
+     * @return string      Namespaced key passed to the object cache API.
+     */
+    private function buildKey(string $key): string
+    {
+        return $this->getPrefix() . '|' . $key;
+    }
+
+    /**
+     * Stores a value in the cache.
+     *
+     * If the entry already exists it will be overwritten. Uses the provider ID
+     * as the object cache group so entries are logically isolated from other data.
+     *
+     * @param string $key   Cache key.
+     * @param mixed  $value Value to store; must be serialisable.
+     */
+    public function add(string $key, mixed $value): void
+    {
+        wp_cache_set($this->buildKey($key), $value, self::ID, $this->getTtl());
+    }
+
+    /**
+     * Retrieves a value from the cache.
+     *
+     * Returns null when the key does not exist. wp_cache_get() returns false on
+     * a cache miss, which is normalised to null to match the interface contract.
+     *
+     * @param  string $key Cache key.
+     * @return mixed       Cached value, or null if the key is not found.
+     */
+    public function get(string $key): mixed
+    {
+        $value = wp_cache_get($this->buildKey($key), self::ID);
+
+        // wp_cache_get returns false on a miss; normalise to null per interface contract.
+        return ($value === false) ? null : $value;
+    }
+
+    /**
+     * Removes a single entry from the cache.
+     *
+     * @param string $key Cache key to delete.
+     */
+    public function invalidate(string $key): void
+    {
+        wp_cache_delete($this->buildKey($key), self::ID);
+    }
+}

--- a/src/Controller/Backend/CacheController.php
+++ b/src/Controller/Backend/CacheController.php
@@ -27,4 +27,18 @@ class CacheController
         $this->cache->invalidate(ObjectMapHandler::POST_TERM_MAP_CACHE_KEY);
         $this->cache->invalidate(ObjectMapHandler::POST_TREE_MAP_CACHE_KEY);
     }
+
+    /**
+     * Flushes all UAM caches when a user group is created, updated, or deleted.
+     *
+     * Group changes affect access decisions and user group memberships across
+     * the entire site. Rather than trying to selectively invalidate individual
+     * cache entries — which would require tracking every user and object
+     * combination — we flush the full cache. This is safe because the cache
+     * is rebuilt on the next request.
+     */
+    public function invalidateUserGroupCaches(): void
+    {
+        $this->cache->flushCache();
+    }
 }

--- a/src/Controller/Backend/SettingsController.php
+++ b/src/Controller/Backend/SettingsController.php
@@ -170,6 +170,11 @@ class SettingsController extends Controller
 
     private function isXSendFileAvailable(): bool
     {
+        // On nginx, X-Accel-Redirect is always available — no HTTP test needed.
+        if ($this->wordpress->isNginx()) {
+            return true;
+        }
+
         $content = @file_get_contents($this->wordpress->getSiteUrl() . '?testXSendFile');
         $this->fileHandler->removeXSendFileTestFile();
 
@@ -193,15 +198,15 @@ class SettingsController extends Controller
 
     private function addLockFileTypes(array $configParameters, array &$parameters): void
     {
-        if (isset($configParameters['lock_file_types']) === true
-            && $this->wordpress->isNginx() === false
-        ) {
+        if (isset($configParameters['lock_file_types']) === true) {
             $parameters['lock_file_types'] = [
                 'selected' => 'locked_file_types',
                 'not_selected' => 'not_locked_file_types'
             ];
 
-            if ($this->wordpress->gotModRewrite() === false) {
+            if ($this->wordpress->isNginx() === false
+                && $this->wordpress->gotModRewrite() === false
+            ) {
                 $parameters[] = 'file_pass_type';
             }
         }

--- a/src/Controller/Backend/SettingsController.php
+++ b/src/Controller/Backend/SettingsController.php
@@ -181,18 +181,38 @@ class SettingsController extends Controller
         return ($content === 'success');
     }
 
-    private function disableXSendFileOption(Form $form): void
+    /**
+     * Configures the xsendfile option in the download-type selector based on the
+     * current web server:
+     *
+     * - nginx: renames the option to "X-Accel-Redirect" and keeps it enabled,
+     *   because X-Accel-Redirect is always available on nginx without any extra
+     *   module.
+     * - Apache (or other): runs the HTTP round-trip test to verify that
+     *   mod_xsendfile is installed. If the test fails the option is marked
+     *   disabled so the admin cannot select a method that will not work.
+     */
+    private function configureXSendFileOption(Form $form): void
     {
         $formElements = $form->getElements();
 
-        if (isset($formElements['download_type']) === true) {
-            /** @var ValueSetFormElement $downloadType */
-            $downloadType = $formElements['download_type'];
-            $possibleValues = $downloadType->getPossibleValues();
+        if (isset($formElements['download_type']) === false) {
+            return;
+        }
 
-            if (isset($possibleValues['xsendfile']) === true) {
-                $possibleValues['xsendfile']->markDisabled();
-            }
+        /** @var ValueSetFormElement $downloadType */
+        $downloadType = $formElements['download_type'];
+        $possibleValues = $downloadType->getPossibleValues();
+
+        if (isset($possibleValues['xsendfile']) === false) {
+            return;
+        }
+
+        if ($this->wordpress->isNginx() === true) {
+            // X-Accel-Redirect is always available on nginx — just relabel the option.
+            $possibleValues['xsendfile']->setLabel(TXT_UAM_DOWNLOAD_TYPE_XACCELREDIRECT);
+        } elseif ($this->isXSendFileAvailable() === false) {
+            $possibleValues['xsendfile']->markDisabled();
         }
     }
 
@@ -242,9 +262,7 @@ class SettingsController extends Controller
 
         $form = $this->formHelper->getSettingsForm($parameters);
 
-        if ($this->isXSendFileAvailable() === false) {
-            $this->disableXSendFileOption($form);
-        }
+        $this->configureXSendFileOption($form);
 
         return $form;
     }

--- a/src/Controller/Backend/UserGroupController.php
+++ b/src/Controller/Backend/UserGroupController.php
@@ -193,6 +193,7 @@ class UserGroupController extends Controller
             }
 
             $this->userGroupHandler->addUserGroup($userGroup);
+            $this->wordpress->doAction('uam_user_group_changed');
         }
     }
 
@@ -208,6 +209,7 @@ class UserGroupController extends Controller
             $this->userGroupHandler->deleteUserGroup($id);
         }
 
+        $this->wordpress->doAction('uam_user_group_changed');
         $this->setUpdateMessage(TXT_UAM_DELETE_GROUP);
     }
 

--- a/src/File/FileHandler.php
+++ b/src/File/FileHandler.php
@@ -95,7 +95,12 @@ class FileHandler
         $downloadType = $this->mainConfig->getDownloadType();
 
         if ($downloadType === 'xsendfile') {
-            header("X-Sendfile: $file");
+            if ($this->wordpress->isNginx()) {
+                $uri = str_replace(rtrim(ABSPATH, '/'), '', $file);
+                header("X-Accel-Redirect: $uri");
+            } else {
+                header("X-Sendfile: $file");
+            }
         }
 
         $this->addDefaultHeader($file, $isInline);

--- a/src/File/FileHandler.php
+++ b/src/File/FileHandler.php
@@ -89,6 +89,20 @@ class FileHandler
         }
     }
 
+    /**
+     * Returns true when Apache's mod_xsendfile module is loaded.
+     *
+     * Used as a runtime guard so that file delivery falls back to fopen when
+     * the admin has selected "X-Sendfile" but the module is not present (e.g.
+     * after a server migration). The check is cheap — apache_get_modules() is
+     * a built-in PHP function available whenever PHP runs under Apache.
+     */
+    private function isApacheXSendFileAvailable(): bool
+    {
+        return $this->php->functionExists('apache_get_modules')
+            && in_array('mod_xsendfile', apache_get_modules(), true);
+    }
+
     private function deliverFile(string $file, bool $isInline): void
     {
         header("HTTP/1.1 200 OK");
@@ -100,8 +114,12 @@ class FileHandler
                 // internal location that bypasses UAM's rewrite rules, avoiding a loop.
                 $uri = '/uam-files' . str_replace(rtrim(ABSPATH, '/'), '', $file);
                 header("X-Accel-Redirect: $uri");
-            } else {
+            } elseif ($this->isApacheXSendFileAvailable()) {
                 header("X-Sendfile: $file");
+            } else {
+                // mod_xsendfile is not available — fall back to fopen so the file
+                // is still delivered rather than sending an empty response.
+                $downloadType = 'fopen';
             }
         }
 

--- a/src/File/FileHandler.php
+++ b/src/File/FileHandler.php
@@ -96,7 +96,9 @@ class FileHandler
 
         if ($downloadType === 'xsendfile') {
             if ($this->wordpress->isNginx()) {
-                $uri = str_replace(rtrim(ABSPATH, '/'), '', $file);
+                // Use /uam-files/ prefix so the internal redirect goes to a dedicated
+                // internal location that bypasses UAM's rewrite rules, avoiding a loop.
+                $uri = '/uam-files' . str_replace(rtrim(ABSPATH, '/'), '', $file);
                 header("X-Accel-Redirect: $uri");
             } else {
                 header("X-Sendfile: $file");

--- a/src/File/FileProtection.php
+++ b/src/File/FileProtection.php
@@ -31,7 +31,7 @@ abstract class FileProtection
         $lockedDirectoryType = $this->mainConfig->getLockedDirectoryType();
 
         if ($lockedDirectoryType === 'wordpress') {
-            $directoryMatch = '[0-9]{4}' . DIRECTORY_SEPARATOR . '[0-9]{2}';
+            $directoryMatch = '\d{4}' . DIRECTORY_SEPARATOR . '\d{2}';
         } elseif ($lockedDirectoryType === 'custom') {
             $directoryMatch = $this->mainConfig->getCustomLockedDirectories();
         }

--- a/src/File/NginxFileProtection.php
+++ b/src/File/NginxFileProtection.php
@@ -29,7 +29,7 @@ class NginxFileProtection extends FileProtection implements FileProtectionInterf
 
         $location = $this->getLocation(str_replace($absolutePath, '/', $directory));
 
-        $content = "location $location {\n";
+        $content = "location ~ \"$location\" {\n";
         $content .= "rewrite ^([^?]*)$ /index.php?uamfiletype=$objectType&uamgetfile=$1 last;\n";
         $content .= "rewrite ^(.*)\\?(((?!uamfiletype).)*)$ ";
         $content .= "/index.php?uamfiletype=$objectType&uamgetfile=$1&$2 last;\n";

--- a/src/Form/LabelTrait.php
+++ b/src/Form/LabelTrait.php
@@ -12,4 +12,9 @@ trait LabelTrait
     {
         return $this->label;
     }
+
+    public function setLabel(string $label): void
+    {
+        $this->label = $label;
+    }
 }

--- a/src/UserAccessManager.php
+++ b/src/UserAccessManager.php
@@ -512,6 +512,7 @@ class UserAccessManager
         $this->wordpress->addFilter('clean_object_term_cache', [$backendCacheController, 'invalidateTermCache']);
         $this->wordpress->addFilter('clean_post_cache', [$backendCacheController, 'invalidatePostCache']);
         $this->wordpress->addFilter('clean_attachment_cache', [$backendCacheController, 'invalidatePostCache']);
+        $this->wordpress->addAction('uam_user_group_changed', [$backendCacheController, 'invalidateUserGroupCaches']);
 
         // Widgets
         $this->wordpress->addAction('widgets_init', function () {

--- a/src/UserGroup/AbstractUserGroup.php
+++ b/src/UserGroup/AbstractUserGroup.php
@@ -118,6 +118,31 @@ abstract class AbstractUserGroup
     }
 
     /**
+     * Pre-populates the in-memory assignment cache for a given object type.
+     *
+     * Called by UserGroupHandler::preloadGroupAssignments() after it fetches all
+     * direct assignments in a single batch query. When getAssignedObjects() is
+     * called afterwards it finds the cache already populated and skips its own
+     * per-group DB query.
+     *
+     * @param array<int|string, object> $rows Raw result rows from the batch query,
+     *                                        keyed by object_id.
+     */
+    public function preloadAssignedObjects(string $objectType, array $rows): void
+    {
+        $this->assignedObjects[$objectType] = [];
+
+        foreach ($rows as $objectId => $row) {
+            $this->assignedObjects[$objectType][$objectId] =
+                $this->assignmentInformationFactory->createAssignmentInformation(
+                    $row->objectType,
+                    $row->fromDate,
+                    $row->toDate
+                );
+        }
+    }
+
+    /**
      * @throws Exception
      */
     public function delete(): bool

--- a/src/UserGroup/UserGroupHandler.php
+++ b/src/UserGroup/UserGroupHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UserAccessManager\UserGroup;
 
 use Exception;
+use UserAccessManager\Cache\Cache;
 use UserAccessManager\Config\MainConfig;
 use UserAccessManager\Config\WordpressConfig;
 use UserAccessManager\Database\Database;
@@ -31,7 +32,8 @@ class UserGroupHandler
         private Database $database,
         private ObjectHandler $objectHandler,
         private UserHandler $userHandler,
-        private UserGroupFactory $userGroupFactory
+        private UserGroupFactory $userGroupFactory,
+        private Cache $cache
     ) {
     }
 
@@ -146,6 +148,63 @@ class UserGroupHandler
      * @throws UserGroupTypeException
      * @throws Exception
      */
+    /**
+     * Pre-fetches all direct group assignments for a given object in a single
+     * DB query and populates each UserGroup's in-memory assignment cache.
+     *
+     * This avoids N separate queries (one per group) when the loop below calls
+     * isObjectMember() → getAssignedObjects() for every group. Custom membership
+     * handlers registered by third-party plugins are unaffected because the
+     * isObjectMember() call path is preserved; only the underlying DB fetch is
+     * short-circuited via the pre-populated cache.
+     */
+    private function preloadGroupAssignments(
+        string $objectType,
+        int|string|null $objectId,
+        array $userGroups,
+        bool $ignoreDates
+    ): void {
+        $generalObjectType = $this->objectHandler->getGeneralObjectType($objectType);
+
+        if ($generalObjectType === null) {
+            return;
+        }
+
+        $query = "SELECT group_id, object_id, object_type AS objectType,
+                         from_date AS fromDate, to_date AS toDate
+                  FROM {$this->database->getUserGroupToObjectTable()}
+                  WHERE object_id = '%s'
+                    AND (object_type = '%s' OR general_object_type = '%s')
+                    AND object_id != ''";
+
+        $parameters = [$objectId, $objectType, $generalObjectType];
+
+        if ($ignoreDates === false) {
+            $query .= " AND (from_date IS NULL OR from_date <= '%s')
+                        AND (to_date IS NULL OR to_date >= '%s')";
+            $time = $this->wordpress->currentTime('mysql');
+            $parameters[] = $time;
+            $parameters[] = $time;
+        }
+
+        $results = (array) $this->database->getResults(
+            $this->database->prepare($query, $parameters)
+        );
+
+        // Group results by group_id so each UserGroup can receive its slice.
+        $byGroupId = [];
+
+        foreach ($results as $row) {
+            $byGroupId[$row->group_id][$row->object_id] = $row;
+        }
+
+        foreach ($userGroups as $id => $group) {
+            if ($group instanceof UserGroup) {
+                $group->preloadAssignedObjects($objectType, $byGroupId[$id] ?? []);
+            }
+        }
+    }
+
     public function getUserGroupsForObject(
         string $objectType,
         int|string|null $objectId,
@@ -158,6 +217,11 @@ class UserGroupHandler
         if (isset($this->objectUserGroups[$ignoreDates][$objectType][$objectId]) === false) {
             $objectUserGroups = [];
             $userGroups = $this->getFullUserGroups();
+
+            // Pre-fetch all direct DB assignments in one query so that the
+            // isObjectMember() calls below hit in-memory cache instead of
+            // making individual queries per group.
+            $this->preloadGroupAssignments($objectType, $objectId, $userGroups, $ignoreDates);
 
             foreach ($userGroups as $userGroup) {
                 $userGroup->setIgnoreDates($ignoreDates);
@@ -216,6 +280,20 @@ class UserGroupHandler
      * @return AbstractUserGroup[]|null
      * @throws UserGroupTypeException
      */
+    /**
+     * Returns the IDs of the static UserGroups the given user belongs to,
+     * either from the persistent cache or by querying the database.
+     *
+     * Only static UserGroup IDs (integers) are cached. DynamicUserGroups are
+     * cheap to reconstruct and are never serialised to the cache.
+     *
+     * @return int[]
+     */
+    private function getCachedStaticGroupIdsForUser(WP_User $currentUser): ?array
+    {
+        return $this->cache->get('uam_ugfu_' . $currentUser->ID);
+    }
+
     public function getUserGroupsForUser(): ?array
     {
         if ($this->userHandler->checkUserAccess(UserHandler::MANAGE_USER_GROUPS_CAPABILITY) === true) {
@@ -224,20 +302,45 @@ class UserGroupHandler
 
         if ($this->userGroupsForUser === null) {
             $currentUser = $this->wordpress->getCurrentUser();
-            $userGroupsForUser = $this->getUserGroupsForObject(
-                ObjectHandler::GENERAL_USER_OBJECT_TYPE,
-                $currentUser->ID
-            );
+            $cachedIds = $this->getCachedStaticGroupIdsForUser($currentUser);
 
-            $this->assignDynamicUserGroupsForUser($currentUser, $userGroupsForUser);
-            $userGroups = $this->getUserGroups();
+            if ($cachedIds !== null) {
+                // Reconstruct from cached IDs: add dynamic groups (cheap) and
+                // look up the static groups from the already-loaded group list.
+                $userGroupsForUser = [];
+                $this->assignDynamicUserGroupsForUser($currentUser, $userGroupsForUser);
+                $allGroups = $this->getUserGroups();
 
-            foreach ($userGroups as $userGroup) {
-                if (isset($userGroupsForUser[$userGroup->getId()]) === false
-                    && $this->checkUserGroupAccess($userGroup) === true
-                ) {
-                    $userGroupsForUser[$userGroup->getId()] = $userGroup;
+                foreach ($cachedIds as $id) {
+                    if (isset($allGroups[$id])) {
+                        $userGroupsForUser[$id] = $allGroups[$id];
+                    }
                 }
+            } else {
+                $userGroupsForUser = $this->getUserGroupsForObject(
+                    ObjectHandler::GENERAL_USER_OBJECT_TYPE,
+                    $currentUser->ID
+                );
+
+                $this->assignDynamicUserGroupsForUser($currentUser, $userGroupsForUser);
+                $userGroups = $this->getUserGroups();
+
+                foreach ($userGroups as $userGroup) {
+                    if (isset($userGroupsForUser[$userGroup->getId()]) === false
+                        && $this->checkUserGroupAccess($userGroup) === true
+                    ) {
+                        $userGroupsForUser[$userGroup->getId()] = $userGroup;
+                    }
+                }
+
+                // Cache only the static (non-dynamic) group IDs so they survive
+                // across requests. Dynamic groups are excluded because they are
+                // identified by string keys and are trivial to recompute.
+                $staticIds = array_keys(array_filter(
+                    $userGroupsForUser,
+                    static fn($g) => $g instanceof UserGroup
+                ));
+                $this->cache->add('uam_ugfu_' . $currentUser->ID, $staticIds);
             }
 
             $this->userGroupsForUser = $userGroupsForUser;


### PR DESCRIPTION
# nginx support: X-Accel-Redirect, Redis cache provider, and bug fixes

## Summary

This PR adds proper nginx support to UAM's file protection and delivery pipeline, introduces a Redis-backed cache provider, and fixes three bugs discovered during testing.

---

## nginx file delivery via X-Accel-Redirect

nginx does not support the Apache `X-Sendfile` header. UAM's existing xsendfile setting was therefore unusable on nginx installs. This PR adds native nginx support:

- **`FileHandler`**: detects nginx via `isNginx()` and sends `X-Accel-Redirect` instead of `X-Sendfile`. When PHP sends `X-Accel-Redirect`, nginx handles the file delivery internally — the browser URL never changes and the user never sees this handoff. The URI must be prefixed with `/uam-files/` to avoid an internal redirect loop: without the prefix, nginx receives a URI under `/wp-content/uploads/`, matches the UAM location block, rewrites back to `index.php`, which sends the header again — indefinitely. With the `/uam-files/` prefix the URI matches a dedicated `internal` location that serves the file directly.
- **`SettingsController::isXSendFileAvailable()`**: returns `true` immediately on nginx instead of running the HTTP round-trip test, which only works with Apache mod_xsendfile.
- **`SettingsController::addLockFileTypes()`**: removed the `isNginx()` guard that incorrectly hid the `lock_file_types` setting on nginx.
- **`NginxFileProtection`**: fixed the generated location block — added the `~` flag and quoted the regex, which is required when the pattern contains curly braces.
- **`FileProtection::getDirectoryMatch()`**: replaced `[0-9]{4}` with `\d{4}` — nginx's PCRE engine fails to parse character classes with quantifiers in location directives even when quoted.

Unlike Apache, where UAM can write `.htaccess` automatically, nginx configuration files cannot be modified by PHP. The following snippet must be added manually to the nginx server block. Without it, protected files will not be routed through WordPress and file protection will not work.

```nginx
# Route protected uploads through WordPress/UAM
location ~ "^/wp-content/uploads/\d{4}/\d{2}" {
    rewrite ^([^?]*)$ /index.php?uamfiletype=attachment&uamgetfile=$1 last;
    rewrite ^(.*)\?(((?!uamfiletype).)*)$ /index.php?uamfiletype=attachment&uamgetfile=$1&$2 last;
    rewrite ^(.*)\?(.*)$ /index.php?uamgetfile=$1&$2 last;
}

# Internal location for X-Accel-Redirect — bypasses UAM rewrite rules
location /uam-files/ {
    internal;
    alias /path/to/wordpress/;
}
```

---

## Server-aware download type label and Apache runtime fallback

The download-type selector always showed "X-Sendfile" regardless of web server. This was misleading on nginx installs.

- On **nginx** the option is relabelled to "X-Accel-Redirect" and stays enabled, because X-Accel-Redirect is always available without any extra module.
- On **Apache** the existing HTTP round-trip test still runs; if mod_xsendfile is absent the option is disabled as before.
- Added a **runtime fallback** in `FileHandler`: if "xsendfile" is saved in the database but Apache's `mod_xsendfile` is not loaded at request time (e.g. after a server migration), delivery silently falls back to `fopen` instead of returning an empty response.

---

## Redis cache provider

Adds `RedisCacheProvider` implementing `CacheProviderInterface`, backed by the WordPress object cache API (`wp_cache_get/set/delete`). The provider is automatically registered when `wp_using_ext_object_cache()` returns `true` (i.e. a persistent object cache such as Redis or Memcached is active). Language strings and `.pot` entries are included.

---

## Performance: cross-request caching and batch-load optimization

Three complementary improvements that reduce database queries on every page load:

- **`checkObjectAccess()` persistent cache**: access decisions are stored in the active cache provider (Redis when available, filesystem otherwise), keyed by user ID, object type and object ID. A page listing 20 protected posts goes from 20+ DB queries to zero after the first load.
- **`getUserGroupsForUser()` persistent cache**: the static group IDs for each user are cached across requests. Dynamic groups are excluded from the cache as they are trivial to recompute. Result: the per-user group membership query is eliminated on subsequent requests.
- **Batch-load of group assignments**: `getUserGroupsForObject()` previously issued one DB query per group to check object membership (N queries per object). A single pre-fetch query now loads all direct assignments at once and populates each group's in-memory cache before the loop runs. The `isObjectMember()` call path and `ObjectMembershipHandler` layer are fully preserved, keeping compatibility with third-party plugins that register custom membership handlers.

Cache invalidation: a new `uam_user_group_changed` action is dispatched by `UserGroupController` after any group create, update or delete. The `CacheController::invalidateUserGroupCaches()` handler flushes the full UAM cache, ensuring stale access decisions are never served after a group change.

---

## Bug fix: `hasAuthorAccess` with `post_author = 0`

When a post has `post_author = 0` (common with imported content), unauthenticated users (whose ID is also `0`) were incorrectly treated as the post author, granting them access regardless of group restrictions. Added a `$currentUserId !== 0` guard in `AccessHandler::hasAuthorAccess()`.

---

## Testing

All scenarios verified on a live nginx + PHP-FPM + Redis install:

- Unauthenticated → group-restricted file → **403** ✅
- Logged in, not in group → group-restricted file → **403** ✅
- Logged in, in group → group-restricted file → **200** + X-Accel-Redirect ✅
- Unauthenticated → unrestricted file → **200** ✅