### PR TITLE
Reduce database queries with batch-loading and cross-request caching

### DIFF
--- a/init.php
+++ b/init.php
@@ -87,7 +87,8 @@ function initUserAccessManger()
         $database,
         $objectHandler,
         $userHandler,
-        $userGroupFactory
+        $userGroupFactory,
+        $cache
     );
     $accessHandler = new AccessHandler(
         $wordpress,
@@ -95,7 +96,8 @@ function initUserAccessManger()
         $database,
         $objectHandler,
         $userHandler,
-        $userGroupHandler
+        $userGroupHandler,
+        $cache
     );
     $fileProtectionFactory = new FileProtectionFactory(
         $php,

--- a/src/Access/AccessHandler.php
+++ b/src/Access/AccessHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UserAccessManager\Access;
 
 use Exception;
+use UserAccessManager\Cache\Cache;
 use UserAccessManager\Config\MainConfig;
 use UserAccessManager\Database\Database;
 use UserAccessManager\Object\ObjectHandler;
@@ -27,8 +28,24 @@ class AccessHandler
         private Database $database,
         private ObjectHandler $objectHandler,
         private UserHandler $userHandler,
-        private UserGroupHandler $userGroupHandler
+        private UserGroupHandler $userGroupHandler,
+        private Cache $cache
     ) {
+    }
+
+    /**
+     * Builds a cache key for a specific access decision.
+     *
+     * The key encodes the user ID, admin flag, object type and object ID so
+     * that results for different users and objects are stored independently.
+     */
+    private function buildAccessCacheKey(
+        int $userId,
+        bool $isAdmin,
+        ?string $objectType,
+        int|string|null $objectId
+    ): string {
+        return 'uam_access_' . $userId . '_' . (int) $isAdmin . '_' . $objectType . '_' . $objectId;
     }
 
     private function hasAuthorAccess(string $objectType, int|string|null $objectId): bool
@@ -77,22 +94,33 @@ class AccessHandler
         $isAdmin = $this->isAdmin($isAdmin);
 
         if (isset($this->objectAccess[$isAdmin][$objectType][$objectId]) === false) {
-            if ($this->objectHandler->isValidObjectType($objectType) === false
-                || $this->userHandler->checkUserAccess(UserHandler::MANAGE_USER_GROUPS_CAPABILITY) === true
-                || $this->hasAuthorAccess($objectType, $objectId) === true
-            ) {
-                $access = true;
+            $userId = $this->wordpress->getCurrentUser()->ID;
+            $cacheKey = $this->buildAccessCacheKey($userId, $isAdmin, $objectType, $objectId);
+            $cached = $this->cache->get($cacheKey);
+
+            if ($cached !== null) {
+                // Warm the in-memory cache from the persistent cache so subsequent
+                // calls within the same request do not hit the cache provider again.
+                $this->objectAccess[$isAdmin][$objectType][$objectId] = (bool) $cached;
             } else {
-                $membership = $this->userGroupHandler->getUserGroupsForObject($objectType, $objectId);
-                $access = $membership === []
-                    || array_intersect_key($membership, $this->getUserUserGroupsForObjectAccess($isAdmin)) !== [];
+                if ($this->objectHandler->isValidObjectType($objectType) === false
+                    || $this->userHandler->checkUserAccess(UserHandler::MANAGE_USER_GROUPS_CAPABILITY) === true
+                    || $this->hasAuthorAccess($objectType, $objectId) === true
+                ) {
+                    $access = true;
+                } else {
+                    $membership = $this->userGroupHandler->getUserGroupsForObject($objectType, $objectId);
+                    $access = $membership === []
+                        || array_intersect_key($membership, $this->getUserUserGroupsForObjectAccess($isAdmin)) !== [];
 
-                if ($access && $this->wordpress->isUserLoggedIn() && $this->wordpress->isMultiSite()) {
-                    $access = $this->wordpress->isUserMemberOfBlog();
+                    if ($access && $this->wordpress->isUserLoggedIn() && $this->wordpress->isMultiSite()) {
+                        $access = $this->wordpress->isUserMemberOfBlog();
+                    }
                 }
-            }
 
-            $this->objectAccess[$isAdmin][$objectType][$objectId] = $access;
+                $this->objectAccess[$isAdmin][$objectType][$objectId] = $access;
+                $this->cache->add($cacheKey, $access);
+            }
         }
 
         return $this->objectAccess[$isAdmin][$objectType][$objectId];

--- a/src/Controller/Backend/CacheController.php
+++ b/src/Controller/Backend/CacheController.php
@@ -27,4 +27,18 @@ class CacheController
         $this->cache->invalidate(ObjectMapHandler::POST_TERM_MAP_CACHE_KEY);
         $this->cache->invalidate(ObjectMapHandler::POST_TREE_MAP_CACHE_KEY);
     }
+
+    /**
+     * Flushes all UAM caches when a user group is created, updated, or deleted.
+     *
+     * Group changes affect access decisions and user group memberships across
+     * the entire site. Rather than trying to selectively invalidate individual
+     * cache entries — which would require tracking every user and object
+     * combination — we flush the full cache. This is safe because the cache
+     * is rebuilt on the next request.
+     */
+    public function invalidateUserGroupCaches(): void
+    {
+        $this->cache->flushCache();
+    }
 }

--- a/src/Controller/Backend/UserGroupController.php
+++ b/src/Controller/Backend/UserGroupController.php
@@ -193,6 +193,7 @@ class UserGroupController extends Controller
             }
 
             $this->userGroupHandler->addUserGroup($userGroup);
+            $this->wordpress->doAction('uam_user_group_changed');
         }
     }
 
@@ -208,6 +209,7 @@ class UserGroupController extends Controller
             $this->userGroupHandler->deleteUserGroup($id);
         }
 
+        $this->wordpress->doAction('uam_user_group_changed');
         $this->setUpdateMessage(TXT_UAM_DELETE_GROUP);
     }
 

--- a/src/UserAccessManager.php
+++ b/src/UserAccessManager.php
@@ -512,6 +512,7 @@ class UserAccessManager
         $this->wordpress->addFilter('clean_object_term_cache', [$backendCacheController, 'invalidateTermCache']);
         $this->wordpress->addFilter('clean_post_cache', [$backendCacheController, 'invalidatePostCache']);
         $this->wordpress->addFilter('clean_attachment_cache', [$backendCacheController, 'invalidatePostCache']);
+        $this->wordpress->addAction('uam_user_group_changed', [$backendCacheController, 'invalidateUserGroupCaches']);
 
         // Widgets
         $this->wordpress->addAction('widgets_init', function () {

--- a/src/UserGroup/AbstractUserGroup.php
+++ b/src/UserGroup/AbstractUserGroup.php
@@ -118,6 +118,31 @@ abstract class AbstractUserGroup
     }
 
     /**
+     * Pre-populates the in-memory assignment cache for a given object type.
+     *
+     * Called by UserGroupHandler::preloadGroupAssignments() after it fetches all
+     * direct assignments in a single batch query. When getAssignedObjects() is
+     * called afterwards it finds the cache already populated and skips its own
+     * per-group DB query.
+     *
+     * @param array<int|string, object> $rows Raw result rows from the batch query,
+     *                                        keyed by object_id.
+     */
+    public function preloadAssignedObjects(string $objectType, array $rows): void
+    {
+        $this->assignedObjects[$objectType] = [];
+
+        foreach ($rows as $objectId => $row) {
+            $this->assignedObjects[$objectType][$objectId] =
+                $this->assignmentInformationFactory->createAssignmentInformation(
+                    $row->objectType,
+                    $row->fromDate,
+                    $row->toDate
+                );
+        }
+    }
+
+    /**
      * @throws Exception
      */
     public function delete(): bool

--- a/src/UserGroup/UserGroupHandler.php
+++ b/src/UserGroup/UserGroupHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UserAccessManager\UserGroup;
 
 use Exception;
+use UserAccessManager\Cache\Cache;
 use UserAccessManager\Config\MainConfig;
 use UserAccessManager\Config\WordpressConfig;
 use UserAccessManager\Database\Database;
@@ -31,7 +32,8 @@ class UserGroupHandler
         private Database $database,
         private ObjectHandler $objectHandler,
         private UserHandler $userHandler,
-        private UserGroupFactory $userGroupFactory
+        private UserGroupFactory $userGroupFactory,
+        private Cache $cache
     ) {
     }
 
@@ -146,6 +148,63 @@ class UserGroupHandler
      * @throws UserGroupTypeException
      * @throws Exception
      */
+    /**
+     * Pre-fetches all direct group assignments for a given object in a single
+     * DB query and populates each UserGroup's in-memory assignment cache.
+     *
+     * This avoids N separate queries (one per group) when the loop below calls
+     * isObjectMember() → getAssignedObjects() for every group. Custom membership
+     * handlers registered by third-party plugins are unaffected because the
+     * isObjectMember() call path is preserved; only the underlying DB fetch is
+     * short-circuited via the pre-populated cache.
+     */
+    private function preloadGroupAssignments(
+        string $objectType,
+        int|string|null $objectId,
+        array $userGroups,
+        bool $ignoreDates
+    ): void {
+        $generalObjectType = $this->objectHandler->getGeneralObjectType($objectType);
+
+        if ($generalObjectType === null) {
+            return;
+        }
+
+        $query = "SELECT group_id, object_id, object_type AS objectType,
+                         from_date AS fromDate, to_date AS toDate
+                  FROM {$this->database->getUserGroupToObjectTable()}
+                  WHERE object_id = '%s'
+                    AND (object_type = '%s' OR general_object_type = '%s')
+                    AND object_id != ''";
+
+        $parameters = [$objectId, $objectType, $generalObjectType];
+
+        if ($ignoreDates === false) {
+            $query .= " AND (from_date IS NULL OR from_date <= '%s')
+                        AND (to_date IS NULL OR to_date >= '%s')";
+            $time = $this->wordpress->currentTime('mysql');
+            $parameters[] = $time;
+            $parameters[] = $time;
+        }
+
+        $results = (array) $this->database->getResults(
+            $this->database->prepare($query, $parameters)
+        );
+
+        // Group results by group_id so each UserGroup can receive its slice.
+        $byGroupId = [];
+
+        foreach ($results as $row) {
+            $byGroupId[$row->group_id][$row->object_id] = $row;
+        }
+
+        foreach ($userGroups as $id => $group) {
+            if ($group instanceof UserGroup) {
+                $group->preloadAssignedObjects($objectType, $byGroupId[$id] ?? []);
+            }
+        }
+    }
+
     public function getUserGroupsForObject(
         string $objectType,
         int|string|null $objectId,
@@ -158,6 +217,11 @@ class UserGroupHandler
         if (isset($this->objectUserGroups[$ignoreDates][$objectType][$objectId]) === false) {
             $objectUserGroups = [];
             $userGroups = $this->getFullUserGroups();
+
+            // Pre-fetch all direct DB assignments in one query so that the
+            // isObjectMember() calls below hit in-memory cache instead of
+            // making individual queries per group.
+            $this->preloadGroupAssignments($objectType, $objectId, $userGroups, $ignoreDates);
 
             foreach ($userGroups as $userGroup) {
                 $userGroup->setIgnoreDates($ignoreDates);
@@ -216,6 +280,20 @@ class UserGroupHandler
      * @return AbstractUserGroup[]|null
      * @throws UserGroupTypeException
      */
+    /**
+     * Returns the IDs of the static UserGroups the given user belongs to,
+     * either from the persistent cache or by querying the database.
+     *
+     * Only static UserGroup IDs (integers) are cached. DynamicUserGroups are
+     * cheap to reconstruct and are never serialised to the cache.
+     *
+     * @return int[]
+     */
+    private function getCachedStaticGroupIdsForUser(WP_User $currentUser): ?array
+    {
+        return $this->cache->get('uam_ugfu_' . $currentUser->ID);
+    }
+
     public function getUserGroupsForUser(): ?array
     {
         if ($this->userHandler->checkUserAccess(UserHandler::MANAGE_USER_GROUPS_CAPABILITY) === true) {
@@ -224,20 +302,45 @@ class UserGroupHandler
 
         if ($this->userGroupsForUser === null) {
             $currentUser = $this->wordpress->getCurrentUser();
-            $userGroupsForUser = $this->getUserGroupsForObject(
-                ObjectHandler::GENERAL_USER_OBJECT_TYPE,
-                $currentUser->ID
-            );
+            $cachedIds = $this->getCachedStaticGroupIdsForUser($currentUser);
 
-            $this->assignDynamicUserGroupsForUser($currentUser, $userGroupsForUser);
-            $userGroups = $this->getUserGroups();
+            if ($cachedIds !== null) {
+                // Reconstruct from cached IDs: add dynamic groups (cheap) and
+                // look up the static groups from the already-loaded group list.
+                $userGroupsForUser = [];
+                $this->assignDynamicUserGroupsForUser($currentUser, $userGroupsForUser);
+                $allGroups = $this->getUserGroups();
 
-            foreach ($userGroups as $userGroup) {
-                if (isset($userGroupsForUser[$userGroup->getId()]) === false
-                    && $this->checkUserGroupAccess($userGroup) === true
-                ) {
-                    $userGroupsForUser[$userGroup->getId()] = $userGroup;
+                foreach ($cachedIds as $id) {
+                    if (isset($allGroups[$id])) {
+                        $userGroupsForUser[$id] = $allGroups[$id];
+                    }
                 }
+            } else {
+                $userGroupsForUser = $this->getUserGroupsForObject(
+                    ObjectHandler::GENERAL_USER_OBJECT_TYPE,
+                    $currentUser->ID
+                );
+
+                $this->assignDynamicUserGroupsForUser($currentUser, $userGroupsForUser);
+                $userGroups = $this->getUserGroups();
+
+                foreach ($userGroups as $userGroup) {
+                    if (isset($userGroupsForUser[$userGroup->getId()]) === false
+                        && $this->checkUserGroupAccess($userGroup) === true
+                    ) {
+                        $userGroupsForUser[$userGroup->getId()] = $userGroup;
+                    }
+                }
+
+                // Cache only the static (non-dynamic) group IDs so they survive
+                // across requests. Dynamic groups are excluded because they are
+                // identified by string keys and are trivial to recompute.
+                $staticIds = array_keys(array_filter(
+                    $userGroupsForUser,
+                    static fn($g) => $g instanceof UserGroup
+                ));
+                $this->cache->add('uam_ugfu_' . $currentUser->ID, $staticIds);
             }
 
             $this->userGroupsForUser = $userGroupsForUser;


### PR DESCRIPTION
## Summary

On sites with many protected posts or large user groups, UAM can generate
a high number of repeated database queries per page load — one per object
per access check. This PR addresses that in two complementary ways:

**Batch SQL loading**
`UserGroupHandler::getUserGroupsForObject()` previously issued one query
per object inside a loop. It now pre-loads all direct assignments in a
single SQL query via the new `AbstractUserGroup::preloadAssignedObjects()`
method, reducing N queries to 1. The `isObjectMember()` layer is kept
intact for plugin compatibility.

**Cross-request caching**
`AccessHandler::checkObjectAccess()` caches results per user+object
(Redis or filesystem), so repeated checks for the same object within a
request are free. `UserGroupHandler::getUserGroupsForUser()` similarly
caches static group IDs per user.

**Cache invalidation**
A new `uam_user_group_changed` action is dispatched by `UserGroupController`
after save/delete. `CacheController::invalidateUserGroupCaches()` flushes
the full cache on change. Dynamic user groups are never cached.

Note: this PR is independent of #433 and can be reviewed/merged separately.

Replaces #432 (splitting as requested).