### PR TITLE
Fix fatal type error in switch_to_blog wrapper

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: member access, user access manager, user management, access
 Requires at least: 4.7
 Requires PHP: 8.0
 Tested up to: 7.0
-Stable tag: 2.3.16
+Stable tag: 2.3.17
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,7 @@ Here you found the changes in each version.
 
     Version     Date        Changes
 
+    2.3.17      2026/07/31  Fix a fatal type error in the switch_to_blog wrapper during the multisite database update
     2.3.16      2026/07/27  Improve performance by loading the object assignments of all user groups with one query
                             Improve performance by loading all user groups with one query instead of one per group
                             Fix the never executed database update of the user group table id column

--- a/src/Wrapper/Wordpress.php
+++ b/src/Wrapper/Wordpress.php
@@ -227,7 +227,7 @@ class Wordpress
     public function switchToBlog(int|string|null $blogId): bool
     {
         if (function_exists('\switch_to_blog') === true) {
-            return switch_to_blog($blogId);
+            return (bool) switch_to_blog($blogId);
         }
 
         return true;

--- a/user-access-manager.php
+++ b/user-access-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: User Access Manager
  * Plugin URI: https://wordpress.org/plugins/user-access-manager/
  * Author URI: https://twitter.com/GM_Alex
- * Version: 2.3.16
+ * Version: 2.3.17
  * Requires PHP: 8.0
  * Author: Alexander Schneider
  * Description: Manage the access to your posts, pages, categories and files.


### PR DESCRIPTION
switch_to_blog() can return an int (the blog id) in some multisite environments, which violated the wrapper's ': bool' return type and caused a fatal TypeError during the setup database update. Cast the return value to bool. Bump version to 2.3.17.